### PR TITLE
Update license as BSD 2-Clause per signed project charter

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-BSD 3-Clause License
+BSD 2-Clause License
 
 Copyright (c) 2019, Robert "Eli" Levasseur, Harrison Leong, Justin W. Flory,
 Lei Mon, Nathaniel Larrimore.
@@ -13,10 +13,6 @@ modification, are permitted provided that the following conditions are met:
 2. Redistributions in binary form must reproduce the above copyright notice,
    this list of conditions and the following disclaimer in the documentation
    and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ _More coming soon!_
 
 ## Legal
 
-Licensed under [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause).
+Licensed under [2-Clause BSD License](https://opensource.org/licenses/BSD-2-Clause).


### PR DESCRIPTION
@nlmeminger pointed out to me that I used the wrong version of the BSD License in the repo, versus the BSD 2-Clause license mentioned in our signed project charter.