### PR TITLE
README: Add README badge for current status of docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 django-rit-grasa
 ================
 
+[![Documentation Status](https://readthedocs.org/projects/django-rit-grasa/badge/?version=latest)](https://django-rit-grasa.readthedocs.io/en/latest/?badge=latest)
+
 Django web application used by Greater Rochester After-School Alliance (GRASA) to improve access to after-school programs in Monroe County, NY
 
 


### PR DESCRIPTION
This is a simple change to add a badge to our project README with a link to our project documentation and the current build status of the docs. Our docs are now publishing here:

https://django-rit-grasa.readthedocs.io/en/latest/