### PR TITLE
adding depends_on option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: Dockerfile
     container_name: Grasa-Django-App
     network_mode: host
+    depends_on:
+      - db
     ports:
       - 80:8000
   db:


### PR DESCRIPTION
There is a bug where the containers did not properly come back up after being stopped.