### PR TITLE
development: Set ALLOWED_HOSTS to "*"

### DIFF
--- a/grasa_event_locator/settings/development.py
+++ b/grasa_event_locator/settings/development.py
@@ -5,9 +5,9 @@ DEBUG = True
 INTERNAL_IPS = ["127.0.0.1"]
 
 SECRET_KEY = "secret"
-
-ALLOWED_HOSTS = ["grasa.larrimore.de", "abba.larrimore.de", "127.0.0.1", "hleong.ddns.net"]
-
+ALLOWED_HOSTS = ["*"]
+# DATABASE SETTINGS
+# https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',


### PR DESCRIPTION
This allows any host to connect when running the app as a development
version. This change allows the app to work correctly in a local dev
environment regardless of operating system choice.