### PR TITLE
Standardize development environment on validated working changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ COPY . /usr/src/app
 
 RUN apt-get --yes update \
     && apt-get --yes upgrade \
-    && pip3 install pipenv
+    && pip3 install pipenv \
+    && pip3 install mysqlclient
 
-RUN pip3 install mysqlclient
 RUN pipenv install --system --deploy --dev
 
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - db
     ports:
-      - 16000:8000
+      - 8000:8000
   db:
     image: "mariadb:10.1"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,63 +1,15 @@
 version: '3'
 services:
-  justin:
+  app:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: justin
     depends_on:
       - db
     ports:
-      - 4000:8000
-  nathaniel:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: nathaniel
-    depends_on:
-      - db
-    ports:
-      - 5000:8000
-  lei:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: lei
-    depends_on:
-      - db
-    ports:
-      - 3000:8000
-  harrison:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: harrison
-    depends_on:
-      - db
-    ports:
-      - 7000:8000
-  eli:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: eli
-    depends_on:
-      - db
-    ports:
-      - 8000:8000
-  lauren:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: lauren
-    depends_on:
-      - db
-    ports:
-      - 9000:8000
+      - 16000:8000
   db:
     image: "mariadb:10.1"
-    volumes:
-      - "~/.cache/django-rit-grasa-db:/var/lib/mysql:z"
     ports:
       - 3306:3306
     environment:
@@ -65,4 +17,3 @@ services:
       - MYSQL_DATABASE=grasa_event_locator
       - MYSQL_USER=grasaadmin
       - MYSQL_PASSWORD=djangoGrasa2019
-

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -53,4 +53,4 @@ To shut down `docker-compose` in detached mode, use this command:
 ## Open in web browser
 
 Once `docker-compose` is running, open a web browser.
-Visit [localhost:8000](http://localhost:8000/) to view the site running locally.
+Visit [localhost:16000](http://localhost:16000/) to view the site running locally.

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -53,4 +53,4 @@ To shut down `docker-compose` in detached mode, use this command:
 ## Open in web browser
 
 Once `docker-compose` is running, open a web browser.
-Visit [localhost:16000](http://localhost:16000/) to view the site running locally.
+Visit [localhost:8000](http://localhost:8000/) to view the site running locally.


### PR DESCRIPTION
This PR includes two commits, explained below:

---

**Dockerfile: Install mysqlclient library in previous layer** (b03ed0c098bfe08ffb6a75be2cf949a5ecc34851)

This moves the `pip3 install` step for the Docker container into the
same layer as system dependencies. This way, the cached version of
mysqlclient is used whenever our project dependencies change.

---

**docker-compose/docs: Run app as single container** (eb9a9e8d7aa7b2d83e78e017ebe638122ca8baa2)

This commit makes changes based on in-person testing and feedback
collected from @ldidonato and @leong96 to get a working Docker Compose
environment working on multiple operating systems.

The docker-compose.yml is reverted to an earlier version. The previous
version created five versions of the application in parallel. This is
hard to test since each team member is using a specific environment to
them. Instead, this commit creates a common environment for everyone to
depend on for the app to work. Doing it this way allows us, as a group,
to quickly be aware if there is a breaking change made to the app
(because it will break for everyone instead of just one person). We
discovered some of this difficulty when debugging with Lauren, Harrison,
and I today.

Lastly, I also updated the docs for the changed port address of running
the application. I changed the port because it is an uncommon port and
it appeared macOS was already doing something on port 8000 and blocked
the app from starting. Using port 16000 for local development was a
random port pick to avoid battling with conflicting ports.