### PR TITLE
mysql: Set sql_mode to STRICT_TRANS_TABLE

### DIFF
--- a/grasa_event_locator/settings/development.py
+++ b/grasa_event_locator/settings/development.py
@@ -16,7 +16,10 @@ DATABASES = {
         'PASSWORD': 'djangoGrasa2019',
         'HOST': 'db',
         'PORT': '3306',
-	'OPTIONS': {'charset': 'utf8mb4'},
+        'OPTIONS': {
+            'charset': 'utf8mb4',
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"
+        },
     }
 }
 CACHES = {
@@ -33,9 +36,9 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 def show_toolbar(request):
     return not request.is_ajax() and request.user and request.user.is_superuser
 
+
 # MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware", ]
 # INSTALLED_APPS += ["debug_toolbar", ]
-
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/grasa_event_locator/settings/production.py
+++ b/grasa_event_locator/settings/production.py
@@ -13,6 +13,10 @@ DATABASES = {
         'PASSWORD': '',
         'HOST': '',
         'PORT': '',
+        'OPTIONS': {
+            'charset': 'utf8mb4',
+            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'"
+        },
     },
 }
 


### PR DESCRIPTION
This commit resolves a warning that crops up whenever we run the
application:

```
WARNINGS:
?: (mysql.W002) MySQL Strict Mode is not set for database connection
    'default'
HINT: MySQL's Strict Mode fixes many data integrity problems in MySQL,
    such as data truncation upon insertion, by escalating warnings into
    errors. It is strongly recommended you activate it. See:
    https://docs.djangoproject.com/en/2.2/ref/databases/#mysql-sql-mode
```

Here are some of my references for why I am making this change:

* https://docs.djangoproject.com/en/2.2/ref/databases/#mysql-sql-mode
* https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-DATABASES
* https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-OPTIONS
* https://stackoverflow.com/a/23023015/2497452

I tested this change locally with `docker-compose` and verified the
warning was resolved.