### PR TITLE
Modal/Create Event (#53)

### DIFF
--- a/grasa_event_locator/templates/allUsers.php
+++ b/grasa_event_locator/templates/allUsers.php
@@ -19,15 +19,10 @@
                   <th scope="row">{{ user.org_name }}</th>
                   <td><a href="mailto:{{ user.user }}">{{ user.user }}</a></td>
                   <td> TBD </td>
-                  <td><button type="button" class="btn btn-outline-danger" data-toggle="modal" data-target="#deleteModal" onclick="window.location.href='{% url 'deny_user' user.id %}'">Delete</button></td>
+                  <td><button type="button" class="btn btn-outline-danger" data-toggle="modal" data-target="#deleteModal">Delete</button></td>
                 </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-    </div>
-</div>
 
-        <!--Delete Modal-->
+                <!--Delete Modal-->
         <div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
           <div class="modal-dialog" role="document">
             <div class="modal-content">
@@ -42,17 +37,24 @@
               </div>
               <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Never Mind</button>
-                <button type="button" class="btn btn-danger" data-dismiss="modal">Confirm Delete</button>
+                <button type="button" class="btn btn-danger" data-dismiss="modal" onclick="window.location.href='{% url 'deny_user' user.id %}'">Confirm Delete</button>
 
               </div>
             </div>
           </div>
         </div>
 
+                {% endfor %}
+              </tbody>
+            </table>
+    </div>
+</div>
+
+
 <script>
     var backBtn = document.getElementById('backBtn');
     backBtn.onclick = function(){
-        window.location = 'admin.php'
+        window.location = 'allUsers.php'
     }
 
 </script>

--- a/grasa_event_locator/templates/createEvent.php
+++ b/grasa_event_locator/templates/createEvent.php
@@ -121,8 +121,8 @@
                 <div class="form-group">
                     <label>Transportation</label>
                     <select class="form-control" name="transportation" required>
-                        <option name="Transportation Not Provided">Transportation Not Provided</option>
-                        <option name="Transportation Provided">Transportation Provided</option>
+                        <option name="Not Provided">Not Provided</option>
+                        <option name="Provided">Provided</option>
                     </select>
                 </div>
                 <div class="form-group text-left multiBox">

--- a/grasa_event_locator/templates/index.php
+++ b/grasa_event_locator/templates/index.php
@@ -45,9 +45,12 @@
                         </div>
                         <div class="col-sm-6 right-info">
                                 {% for t in event.categories.all %}
-                                <span class="badge badge-info card-title">
-                                {{ t }}
-                                </span>
+                                    {% if t.id <= 18 %}
+                                        <span class="badge badge-info card-title">
+                                        {{ t }}
+                                        </span>
+                                    {% else %}
+                                    {% endif %}
                                 {% endfor %}
                             <h6 class="card-subtitle mb-2 text-muted"><i class="fa fa-map-marker" aria-hidden="true"></i> {{ event.address }}</h6>
                         </div>

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -75,9 +75,9 @@ def admin_user(request):
         table.save()
         table = Category(description="Other")
         table.save()
-        table = Category(description="Transportation Not Provided")
+        table = Category(description="Not Provided")
         table.save()
-        table = Category(description="Transportation Provided")
+        table = Category(description="Provided")
         table.save()
         table = Category(description="K-3rd")
         table.save()
@@ -205,7 +205,6 @@ def event(request, eventID):
         transportation_list = transportation_list.filter(id__lte=20)
         for t in transportation_list:
                 transportation_list_pub = transportation_list_pub + str(t)
-        transportation_list_pub = transportation_list_pub[15:]
 
         context = {'event' : event, 'topic_list' : topic_list, 'grades_list_pub' : grades_list_pub, 'timing_list_pub' : timing_list_pub, 'gender_list_pub' : gender_list_pub, 'transportation_list_pub' : transportation_list_pub}
 
@@ -213,8 +212,7 @@ def event(request, eventID):
 
 def index(request):
         allEventList = Program.objects.filter(isPending=False)
-
-        context = {'allEventList': allEventList,}
+        context = {'allEventList': allEventList}
         return render(request, 'index.php', context)
 
 def login(request):


### PR DESCRIPTION
* Modal/Create Event

Reverted modal to original behavior - it will now show, but will always delete the administrator account. Eli is going to take a stab at this.

Create Event: Switched "lng" out for "lon" and returned those fields to being hidden.

* Lon / Lng

"lng" is required by the API. As such, all instances of "lon" have been replaced by "lng".

* Transportation / Index

This commit removed Transportation from the appropriate strings, and makes it so that only activity categories are seen in index.php.