### PR TITLE
docs: Create howto docs for Docker debugging and rebuilding indexes

### DIFF
--- a/docs/howto/exec-container.md
+++ b/docs/howto/exec-container.md
@@ -1,0 +1,30 @@
+How to: Exec into a container
+=============================
+
+This how-to article explains how to open a shell inside of a Docker container for advanced debugging capabilities.
+
+
+## Background
+
+Containers add a large of abstraction to working on the project.
+Or said differently, they hide many parts of your environment, compared to running it locally.
+Sometimes you need more advanced commands or functionality to debug a tricky problem.
+This guide teaches how to debug issues by opening a shell inside of a container.
+
+
+## Pre-requirements
+
+**Docker** and **Docker Compose** should be installed.
+This guide is written for the **command-line interface** of Docker.
+This varies across operating systems, but refer to [Docker docs](https://docs.docker.com/install/) for more help.
+
+Start the local containers with `docker-compose up`.
+In a new window, note the names of the running containers (`docker ps`); you will need the name of the `web` container later.
+
+
+## Commands
+
+```sh
+$ docker exec -it <container name> <"echo 'Some command here'">
+$ docker exec -it web_1 /usr/bin/bash
+```

--- a/docs/howto/rebuild-indexes.md
+++ b/docs/howto/rebuild-indexes.md
@@ -1,0 +1,39 @@
+How to: Rebuild search indexes
+==============================
+
+This is a how-to article to rebuild the Whoosh/Haystack search indexes when new events are added to the database.
+
+
+## Background
+
+New events are added to the database periodically.
+For the new events to appear in search, the index needs to be rebuilt.
+Once the index is rebuilt to include new events, they will appear in searches.
+
+### Development note
+
+Automatic rebuilding of search indexes is planned.
+These steps are mostly intended for local development or to force a index rebuild.
+
+
+## Pre-requirements
+
+If running the project as a container, use `docker exec` to open a shell inside the web app container.
+See the [How to: Exec into a container](/howto/exec-container) doc for more info of how to do this.
+
+If not running the project as a container, get to the environment where your Python 3 + Django installation exists.
+
+
+## Commands
+
+If building index for first time:
+
+```sh
+python3 manage.py rebuild_index
+```
+
+If refreshing for new data, e.g. a new event:
+
+```sh
+python3 manage.py update_index
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,14 @@ For more information, see the `repo on GitHub <https://github.com/jwflory/django
 
 .. toctree::
     :maxdepth: 2
+    :name: howto
+    :caption: Howto articles
+    :glob:
+
+    howto/*
+
+.. toctree::
+    :maxdepth: 2
     :name: development
     :caption: Development
     :glob:


### PR DESCRIPTION
This commit creates a new type of quick doc format, in the form of howto
articles. It includes two new articles: one about using `docker exec` to
get into a container's shell, and another for rebuilding the search
index based on an overview from @eguy006.

![Preview of rendered docs page for using docker exec](https://user-images.githubusercontent.com/4721034/66967330-a6ea5080-f04e-11e9-9375-ecbf894bd797.png "Preview of rendered docs page for using docker exec")

![Preview of rendered docs page for regenerating the search index](https://user-images.githubusercontent.com/4721034/66967360-bf5a6b00-f04e-11e9-9e8b-188d6b36fd96.png "Preview of rendered docs page for regenerating the search index")