### PR TITLE
docs: Add Troubleshooting section to dev env doc, misc. refactoring

### DIFF
--- a/docs/dev/howto-add-dependencies.md
+++ b/docs/dev/howto-add-dependencies.md
@@ -1,5 +1,5 @@
-How do I add new dependencies/libraries/frameworks to the project?
-==================================================================
+How to: Add new dependencies / libraries?
+=========================================
 
 If we use a new library or framework, we need to **install it as a dependency** in the project.
 Dependencies are specific versions of third-party software we want to use in the project.

--- a/docs/dev/howto-setup-dev-environment.md
+++ b/docs/dev/howto-setup-dev-environment.md
@@ -31,12 +31,6 @@ docker-compose up
 
 These commands may require `sudo` depending on your operating system and installation option.
 
-#### Build and run in one go
-
-You can merge the above two commands into one step:
-
-`docker-compose up --build`
-
 #### Run docker-compose in detached mode
 
 Detached mode disables an output stream to your terminal.
@@ -54,3 +48,15 @@ To shut down `docker-compose` in detached mode, use this command:
 
 Once `docker-compose` is running, open a web browser.
 Visit [localhost:8000](http://localhost:8000/) to view the site running locally.
+
+
+## Troubleshooting
+
+### Q: On Fedora, `pipenv install` fails with an error: `OSError: mysql_config not found`
+
+Install the `mariadb-connector-c-devel` package.
+It includes the `mysql_config`/`mariadb_config` binary needed to install the `mysqlclient` library.
+
+```sh
+sudo dnf install -y mariadb-connector-c-devel
+```


### PR DESCRIPTION
This commit makes two changes to the dev env docs:

* Drops mention of the `docker-compose up --build` option
* Adds Troubleshooting / Common questions section for us to build up on

I also renamed the title of another doc to be shorter in the sidebar
navigation of the docs site.

![Screenshot of rendered dev environment set-up page with changes](https://user-images.githubusercontent.com/4721034/66967762-101e9380-f050-11e9-9b1d-803785e43fe3.png "Screenshot of rendered dev environment set-up page with changes")