### PR TITLE
Add issue templates for faster filling of issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-new-story-frontend.md
+++ b/.github/ISSUE_TEMPLATE/01-new-story-frontend.md
@@ -1,14 +1,26 @@
+---
+name: New story - front-end
+about: New task or goal for front-end team
+title: 'FE Story: '
+labels: enhancement, frontend
+assignees: ldidonato, leiyinmon
+
+---
+
 # Summary
 
 <!-- one sentence summary of what needs to be done -->
+
 
 # Background
 
 <!-- context or information to understand the task and/or why it needs to be done – don't put implementation details here -->
 
+
 # Details
 
 <!-- details to understand how this task should be completed or carried out – what are the next steps? -->
+
 
 # Outcome
 

--- a/.github/ISSUE_TEMPLATE/02-new-story-backend.md
+++ b/.github/ISSUE_TEMPLATE/02-new-story-backend.md
@@ -1,0 +1,27 @@
+---
+name: New story - back-end
+about: New task or goal for back-end team
+title: 'BE Story: '
+labels: enhancement, backend
+assignees: leong96, eguy006
+
+---
+
+# Summary
+
+<!-- one sentence summary of what needs to be done -->
+
+
+# Background
+
+<!-- context or information to understand the task and/or why it needs to be done – don't put implementation details here -->
+
+
+# Details
+
+<!-- details to understand how this task should be completed or carried out – what are the next steps? -->
+
+
+# Outcome
+
+<!-- one sentence to describe what the end result will be once this ticket is complete -->

--- a/.github/ISSUE_TEMPLATE/03-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/03-bug-report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Quick template to report a bug
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+# Summary
+
+<!-- one sentence summary of problem -->
+
+
+# Affected components
+
+<!-- Add an 'X' between square brackets for choices that apply to this bug. -->
+
+- [ ] Authentication
+- [ ] Event curation system
+- [ ] Search
+- [ ] Admin portal
+- [ ] Other (explain below)
+
+
+# Suggested fix
+
+<!-- If you have a hunch or an idea of how to fix the bug, explain it here. -->

--- a/.github/ISSUE_TEMPLATE/04-other.md
+++ b/.github/ISSUE_TEMPLATE/04-other.md
@@ -1,0 +1,10 @@
+---
+name: Other
+about: Something that doesn't belong elsewhere
+title: ''
+labels: needs triage
+assignees: ''
+
+---
+
+<!-- This is a free-form ticket. You decide how to write it. Please add background and details if this is not a quick fix or change. -->


### PR DESCRIPTION
This commit adds a set of templates for us to use for quick entry of
information into GitHub issues. It includes three templates:

* New story: front-end
* New story: back-end
* Bug report

"Stories" are the template that existed before, but I split it up by
front-end and back-end to use different default tags and assignees. A
bug report is meant to be a quick and simple template to noting a bug as
we go.