### PR TITLE
Bug template: Add Stacktrace section

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/03-bug-report.md
@@ -11,6 +11,14 @@ assignees: ''
 
 <!-- one sentence summary of problem -->
 
+## Stacktrace
+
+<!-- if you have a stacktrace or log, paste it between the quoted lines below -->
+
+```
+paste logs here
+```
+
 
 # Affected components
 


### PR DESCRIPTION
Since error logs are a common thing to include in a bug report, this
changes our template to add a special plaintext box for error logs, so
they don't fill the entire screen of a GitHub issue.