### PR TITLE
docs: Add setup step for config file

### DIFF
--- a/docs/dev/howto-setup-dev-environment.md
+++ b/docs/dev/howto-setup-dev-environment.md
@@ -17,6 +17,16 @@ This page explains how to set up a local development environment to test the GRA
 * [docker-compose](https://docs.docker.com/compose/install/)
 
 
+## Setup
+
+A configuration file must be provided at start, either as a `config.yml` in the root directory of the project or a path specified as a `CONFIGPATH` environment variable.
+For local development, run the following command to get started with development:
+
+```sh
+cp config.yml.example config.yml
+```
+
+
 ## Run project with docker-compose
 
 `docker-compose` is used for local development.


### PR DESCRIPTION
This commit updates the development environment doc to include a step of
copying the config file over to a new file before building the
container for the first time.

@ldidonato hit this problem after #66 was merged.