### PR TITLE
Dockerfile: Change image to python:3.6 -> python:3.6-stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Local development container. Includes development dependencies.
 # Not to be used in production environment (yet).
-FROM python:3.6
+FROM python:3.6-stretch
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
This fixes an issue hit by Lei since the Python 3.6 image uses an EOL
version of Debian. Whenever she tries to get the repos, apt-get errors
out and fails to build the container.

https://github.com/docker-library/python/issues/386