### PR TITLE
docs: Add page for user testing from @leiyinmon notes

### DIFF
--- a/docs/howto/conduct-user-testing.md
+++ b/docs/howto/conduct-user-testing.md
@@ -1,0 +1,67 @@
+How to: Conduct user testing
+============================
+
+This is a how-to article to explain how to run user testing sessions for the GRASA Event Locator.
+It intends to be a blueprint for these sessions but it is not exhaustive.
+
+
+## Background
+
+User testing is a helpful way to collect feedback about how people use and interact with our application.
+To date, Lei Mon conducted user tests early on in the development cycle.
+This guide is formed from her notes and questions.
+For consistency's sake, **make sure user tests are as consistent as possible** across sessions.
+
+
+## Questionnaire
+
+These are questions to answer during user testing.
+Feel free to add new ones through a pull request:
+
+1. User demographics
+    * Age, race/ethnicity, occupation, etc.
+    * Ask interviewee how they identify
+2. Estimated background with technology?
+3. Overall familiarity with desktop or mobile devices?
+4. What are users' thoughts while viewing search/filter on the homepage?
+5. How easy or difficult was it to navigate across the pages?
+6. Is there anything the user does not understand?
+7. What are users' overall thoughts on the design and layout?
+8. How long did it take the user to complete a task?
+9. User’s overall satisfaction with website?
+10. What did the user like the most and the least?
+11. Any problems finding the information wanted by the user?
+12. Any difficulties using it on mobile devices?
+13. Does the user prefer a mobile or desktop view?
+
+
+## Tasks
+
+This is an idea list of tasks you can run a user through, depending what user they simulate.
+
+### Admins
+
+* Change Site Logo
+* Approve new user
+* Reject new user
+* Approve new event
+* Reject new event
+
+### Providers
+
+* Login
+* Register
+* Forgot Password
+* Create Event
+* Edit Event
+* Change Organization Logo
+
+### Families
+
+* Filter for an Event
+* View Event
+
+
+## Template
+
+<!-- Coming soon… -->


### PR DESCRIPTION
This commit is a first-stab at making some docs on user testing, based on the [Google Doc](https://docs.google.com/document/d/117sFlT2Vf4czVO82iREwLwr0kanmXrsbQqfBUEPOApY/edit?usp=sharing) @leiyinmon sent me previously.

I still want to make a worksheet format out of this for quickly copying or printing. I didn't get a chance to get that out of the doc yet, but I wanted to get this up before I leave. I'll work on that next week.

![Screenshot of rendered page, "How to: Conduct user testing"](https://i.imgur.com/zFl0g6q.png "Screenshot of rendered page, \"How to: Conduct user testing\"")
