### PR TITLE
adding rebuild of search index on event approval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . /app
 
 RUN apt-get --yes update \
     && apt-get --yes upgrade \
-    && pip3 install pipenv
+    && pip3 install pipenv \
 
 RUN pipenv install --system --deploy --dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . /app
 
 RUN apt-get --yes update \
     && apt-get --yes upgrade \
-    && pip3 install pipenv \
+    && pip3 install pipenv
 
 RUN pipenv install --system --deploy --dev
 

--- a/grasa_event_locator/rebuildIndex.py
+++ b/grasa_event_locator/rebuildIndex.py
@@ -1,0 +1,24 @@
+import subprocess
+import shlex
+import os
+
+
+def rebuildWhooshIndex():
+    PROJECT_PATH = os.path.abspath(os.path.dirname(__name__))
+    command = 'cd {}; yes | python3 manage.py rebuild_index'.format(PROJECT_PATH)
+    command = shlex.quote(command)
+    command = shlex.split(command)
+    process = subprocess.Popen(command, stdout=subprocess.PIPE,stderr=subprocess.PIPE,shell=True)
+    stdout, stderr = process.communicate()
+    stdout = stdout.decode().strip()
+    stderr = stderr.decode().strip()
+    status = process.returncode
+
+
+
+    if status == 0:
+            print(stdout)
+            print('\nindex rebuilt')
+    else:
+            print(stderr)
+            print('\nCould not rebuild index')

--- a/grasa_event_locator/settings/development.py
+++ b/grasa_event_locator/settings/development.py
@@ -35,6 +35,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -348,7 +348,7 @@ def denyUser(request, userID):
                 return redirect("login_page")
 
                 
-def  approveEvent(request, eventID):
+def approveEvent(request, eventID):
         if request.user.is_authenticated and request.user.userinfo.isAdmin and request.user.userinfo.isActive:
                 p = Program.objects.get(pk=eventID)
                 p.isPending = False

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -13,6 +13,7 @@ from haystack.generic_views import SearchView
 from haystack.forms import SearchForm
 import time
 from django.db import *
+import rebuildIndex
 
 def aboutContact(request):
         return render(request, 'aboutContact.php')
@@ -346,11 +347,15 @@ def denyUser(request, userID):
         else:
                 return redirect("login_page")
 
-def approveEvent(request, eventID):
+                
+def  approveEvent(request, eventID):
         if request.user.is_authenticated and request.user.userinfo.isAdmin and request.user.userinfo.isActive:
                 p = Program.objects.get(pk=eventID)
                 p.isPending = False
                 p.save()
+
+                rebuildIndex.rebuildWhooshIndex()
+                
                 return redirect("admin_page")
         else:
                 return redirect("login_page")


### PR DESCRIPTION
This pull request adds a feature to automagically rebuild the search index when a new event is approved by an admin.  this is done by using subprocess to call the manage.py file with the rebuild_index arg