### PR TITLE
Forgot Password

### DIFF
--- a/grasa_event_locator/models.py
+++ b/grasa_event_locator/models.py
@@ -137,3 +137,7 @@ class Program(models.Model):
     def denyProgram(self, id):
         p = self.get_by_id(id)
         p.delete()
+
+class resetPWURLs(models.Model):
+    user_ID = models.TextField(default="DEFAULT PROVIDER")
+    reset_string = models.CharField(max_length=15, default="A DEFAULTSTRING")

--- a/grasa_event_locator/settings/base.py
+++ b/grasa_event_locator/settings/base.py
@@ -185,3 +185,9 @@ LOGGING = {
         }
     }
 }
+
+EMAIL_HOST = "smtp.mail.yahoo.com"
+EMAIL_USE_SSL = True
+EMAIL_PORT = 465
+EMAIL_HOST_USER = "grasatest@yahoo.com"
+EMAIL_HOST_PASSWORD = "duhnsentqrxgadfh"

--- a/grasa_event_locator/settings/development.py
+++ b/grasa_event_locator/settings/development.py
@@ -14,9 +14,6 @@ CACHES = {
     }
 }
 
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-
-
 # DJANGO DEBUG TOOLBAR SETTINGS
 # https://django-debug-toolbar.readthedocs.org
 def show_toolbar(request):

--- a/grasa_event_locator/templates/changePWLogout.php
+++ b/grasa_event_locator/templates/changePWLogout.php
@@ -1,0 +1,41 @@
+{% include "header.php" %}
+
+
+  <div class="form-changePW">
+	<form method="post">
+	{% csrf_token %}
+		<label for="currentPW">New Password</label>
+		<input type="password" id="currentPW" class="form-control" name="new" required autofocus>
+		</br>
+		<label for="newPW">Confirm Password</label>
+		<input type="password" id="newPW" class="form-control" name="confirm" pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{8,}" title="Must contain at least one number and one uppercase and lowercase letter, and at least 8 or more characters" required>
+		<input type="checkbox" onclick="myFunction()"> &nbsp; Show Password
+		</br>
+
+
+	<!--Pop-up confirmation page after clicking submit button on Registration form-->
+	<div class="row">
+        <div class="col-12">
+            <button type="submit" class="btn btn-lg btn-primary btn-block">Submit</button>
+        </div>
+	</div>
+
+	</form>
+  </div>
+
+<script>
+function myFunction() {
+  var x = document.getElementById("currentPW");
+  var y = document.getElementById("newPW");
+  if (x.type === "password" || y.type === "password") {
+    x.type = "text";
+	y.type = "text";
+  } else {
+    x.type = "password";
+	y.type = "password";
+  }
+}
+</script>
+
+{% include "footer.php" %}
+

--- a/grasa_event_locator/templates/resetPW.php
+++ b/grasa_event_locator/templates/resetPW.php
@@ -3,10 +3,10 @@
 
   <div class="form-reset">
 	<h1 class="h3 mb-3 font-weight-normal text-center">Reset Password</h1>
-	<form action="resetPW.php">
-    
+	<form action="resetPW.php" method="post">
+	{% csrf_token %}
 		<label for="resetPW" class="sr-only">Email address</label>
-		<input type="email" id="resetPW" class="form-control" placeholder="Enter Email..." required autofocus>
+		<input type="email" id="resetPW" class="form-control" name="emailAddr" placeholder="Enter Email..." required autofocus>
         <small id="emailHelp" class="form-text text-muted">Please provide the email connected to your account.</small>
 		<input class="btn btn-lg btn-success btn-block top-20" type="submit" value="Submit">
         <p class="text-center top-20"><a href="login.php">Return to Login</a></p>

--- a/grasa_event_locator/urls.py
+++ b/grasa_event_locator/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('deny_event/<eventID>', views.denyEvent, name='deny_event'),
     path('approve_edit/<editID>', views.approveEdit, name='approve_edit'),
     path('deny_edit/<editID>', views.denyEdit, name='deny_edit'),
+    path('changePWLogout/<reset_string>', views.changePWLogout, name='changePW_logout'),
     #path('search/', include('haystack.urls')),
     url(r'^search//?$', views.programSearchView.as_view(), name='haystack_search'),
     #path('search/', views.programSearchView.as_view(), name='haystack_search'),


### PR DESCRIPTION
This commits implements the Forgot Password functionality. A randomly generated string is placed into a table and sent to the user, formatted as the correct URL. It then links to a page which will change the password without requiring a login.

Note that this adds a new table; remember to run makemigrations and migrate.

Models - Added in table for the reset urls.
Base.py - Email information
ChangePWLogout - A new page, mainly a copy of the change password page, with fields renamed for the new purpose. Modal removed, as it is not used in this context.
resetPW - Hook up form to back end.
URLs - add changePWLogout to list of URL's.
views.py - Add code to send an email.