### PR TITLE
Admin / Provider Redirect

### DIFF
--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -33,6 +33,8 @@ def admin(request):
                 context = {'pendingUserList' : pendingUserList, 'pendingEventList' : pendingEventList, 'pendingEditList' : pendingEditList}
 
                 return render(request, "admin.php", context)
+        if request.user.is_authenticated and request.user.userinfo.isAdmin == 0 and request.user.userinfo.isActive:
+                return HttpResponseRedirect('provider.php')
         else:
                 return HttpResponseRedirect("login.php")
         return render(request, 'admin.php')
@@ -235,7 +237,7 @@ def provider(request):
                 context = {'myEventList' : myEventList, 'currentUser' : currentUser}
                 return render(request, "provider.php", context)
         if request.user.is_authenticated and request.user.userinfo.isAdmin and request.user.userinfo.isActive:
-                return render(request, 'index.php', )
+                return HttpResponseRedirect('admin.php')
         else:
                 return HttpResponseRedirect("login.php")
 


### PR DESCRIPTION
Changes earlier behavior (that was broken anyways) as per the discussion in issue #51. Now, if a provider tries to get to admin.php by typing the URL, it will go to the provider page. As such, if an admin tries to get to provider.php, they will be redirected to the admin page.