### PR TITLE
Sprint 4 documentation clean-up and polish

### DIFF
--- a/docs/about/about-project.md
+++ b/docs/about/about-project.md
@@ -6,22 +6,23 @@ About this project
     This makes git diffs easier to read in PRs.
 -->
 
-The GRASA Events Locator is an events locator system to better connect Monroe County families to out-of-school programs in the Greater Rochester area.
-This application was created for the [Greater Rochester After-School Alliance](https://www.racf.org/About/Giving-Circles-Initiatives-and-Partnerships/Greater-Rochester-After-School-Alliance) by Team Platypus at the [Rochester Institute of Technology](https://www.rit.edu/).
+The GRASA Event Locator is an event locator system to connect Monroe County families to out-of-school programs in the Greater Rochester area.
+This application was created for the [Greater Rochester After-School Alliance](https://www.racf.org/About/Giving-Circles-Initiatives-and-Partnerships/Greater-Rochester-After-School-Alliance) and Monroe County, New York by [Team Platypus](#project-team) at the [Rochester Institute of Technology](https://www.rit.edu/).
 
 
 ## High level project description
 
-This takes the form of a web page containing a map that can be searched for programs.
-The user can then be presented with further information and registration options.
-This information was originally delivered via the [Explore Monroe website](http://exploremonroeny.com/calendar) as well as a physical book, the “[Adult Guide to Youth Services](https://www2.monroecounty.gov/files/youth/Adult_Guide%202011.pdf)”, both which GRASA and the Monroe County government wish to retire due to a lack of maintenance.
-Representatives from the sponsor have presented Team Platypus with several examples, including [Newark Thrives](http://youthprogramlocator.newark-thrives.org/) and the [Dallas After-School Network](http://dasn.force.com/dapf/ProgramFinder) as examples of what the final deliverable should look and function similarly to.
+This takes the form of a web page containing a map that can be searched for after-school events.
+Users are presented with further information and registration options.
+This information was originally delivered via the [Explore Monroe website](http://exploremonroeny.com/calendar) as well as a physical book, the “[Adult Guide to Youth Services](https://www2.monroecounty.gov/files/youth/Adult_Guide%202011.pdf)”, both which GRASA and the Monroe County government wish to retire due to lack of maintenance.
+GRASA representatives presented Team Platypus with several examples, including [Newark Thrives](http://youthprogramlocator.newark-thrives.org/) and the [Dallas After-School Network](http://dasn.force.com/dapf/ProgramFinder) as examples of final deliverables.
 
-The main highlight of the Resource Locator is the map.
-Similar to the [Newark Thrives Youth Program Locator](http://youthprogramlocator.newark-thrives.org/), the end user will use a search box, filter categories, and interact with the map to locate programs.
-These will be added to the site by the providers via an account system. An administrator from GRASA and the Monroe County government will approve these accounts, as well as creation and revisions of new programs.
-GRASA and Monroe County administrators can also add resources to a fixed Resources page.
-For the purposes of this project, the Resource Locator is not supported for programs beyond Monroe County.
+The main highlight of the GRASA Event Locator is the map.
+Similar to the [Newark Thrives Youth Program Locator](http://youthprogramlocator.newark-thrives.org/), the end user uses a search box with various filters and an interactive map to locate programs.
+Evemts are added to the site by providers via an account system.
+An administrator from GRASA and the Monroe County government approves these accounts, as well as creation and edits of an event.
+
+For the purposes of this project, the Event Locator does not support programs and events beyond Monroe County.
 
 
 ## Objectives

--- a/docs/about/features.md
+++ b/docs/about/features.md
@@ -4,6 +4,7 @@ Features
 This page references our application features based off system requirements.
 All application features are identified by the following:
 
+```
 * **Status**:
     * Confirmed: Successfully tested items
     * Unconfirmed: Items not yet successfully tested
@@ -11,6 +12,7 @@ All application features are identified by the following:
 * **Technology decision**
 * **Summary of approach**
 * **Completion criteria**
+```
 
 Features are organized below by user groups.
 
@@ -19,95 +21,93 @@ Features are organized below by user groups.
 
 ### Search for different events.
 
-* **Status**: Unconfirmed
-* **Technology decision**: [Haystack](https://haystacksearch.org/)
+* **Status**: Implemented
+* **Technology decision**: [Haystack](https://haystacksearch.org/), [Whoosh](https://whoosh.readthedocs.io/en/latest/intro.html)
 * **Relevant domain(s)**: Database
 * **Summary of approach**: Use Django Haystack to search the database of events using a keyword match search.
 * **Completion criteria**:
-    * Unauthenticated user runs successful search query to return results about after-school programs in an area
-    * Information is provided if it exists; the user is informed if it does not exist
+    * Unauthenticated user runs successful search query to return results about after-school programs in an area.
+    * Information is provided if it exists; the user is informed if it does not exist.
 
 ### Apply filters to better discover events that interest a user.
 
-* **Status**: Unconfirmed
-* **Technology decision**: [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/), [Jinja](https://palletsprojects.com/p/jinja/), YAML config files
+* **Status**: Implemented
+* **Technology decision**: [Haystack](https://haystacksearch.org/), [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/), [Jinja](https://palletsprojects.com/p/jinja/), YAML config files
 * **Relevant domain(s)**: Database
-* **Summary of approach**: Use our existing Forms for events to create search filters that mirror metadata we save in our database.
+* **Summary of approach**: Create Haystack search filters that mirror metadata we save in our database.
 * **Completion criteria**:
-    * Unauthenticated user alters search query by choosing from a list of preset filters
-    * More detailed information is discovered in search when filters are displayed
+    * Unauthenticated user alters search query by choosing from a list of preset filters.
+    * More detailed information is discovered in search when filters are displayed.
 
 ### Find information to learn more about a specific event.
 
-* **Status**: Unconfirmed
+* **Status**: Implemented
 * **Technology decision**: [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/), [Jinja](https://palletsprojects.com/p/jinja/)
 * **Relevant domain(s)**: Database, front-end
 * **Summary of approach**: Create a unique, addressable page for every event by pulling data from the database and injecting it into front-end HTML with Jinja inclusions.
 * **Completion criteria**:
-    * Unauthenticated user is able to navigate to an event’s unique page from search UI
-    * Any user can share a direct link to event page details with another user
+    * Unauthenticated user is able to navigate to an event’s unique page from search UI.
+    * Any user can share a direct link to event page details with another user.
 
 
 ## Program providers
 
-### Add new events with specific session info (dates/time/location) into system for approval by administrators.
+### Add new events with specific metadata into system for approval by administrators.
 
-* **Status**: Confirmed
-* **Technology decision**: [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/), [django-crispy-forms](https://django-crispy-forms.readthedocs.io/en/latest/)
+* **Status**: Implemented
+* **Technology decision**: [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/)
 * **Relevant domain(s)**: Full stack
-* **Summary of approach**: Create Forms (with assistance from django-crispy-forms) to validate user input and create new events in the events database table.
+* **Summary of approach**: Create Forms to validate user input and create new events in the events database table.
 * **Completion criteria**:
-    * Provider is able to log into application
+    * Provider is able to log into application.
     * Provider submits new event for review with required details:
         * Title
-        * Date/time (recurring?)
         * Website
         * Address
         * Suggested age groups
 
 ### Update information for existing events in system for approval by administrators.
 
-* **Status**: Unconfirmed
-* **Technology decision**: [User authentication modules](https://docs.djangoproject.com/en/2.2/topics/auth/) provided in Django, [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/) for basic user input, [django-ckeditor](https://github.com/django-ckeditor/django-ckeditor) for WYSIWYG editor support if time allows
+* **Status**: In progress
+* **Technology decision**: [User authentication modules](https://docs.djangoproject.com/en/2.2/topics/auth/) provided in Django, [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/) for basic user input
 * **Relevant domain(s)**: Full stack
 * **Summary of approach**: Allow an authenticated user to edit Forms for events they themselves have created.
 * **Completion criteria**:
-    * Provider is able to log into application
-    * Provider edits an existing event that they already contributed
-    * Event re-enters review queue for admin users
+    * Provider is able to log into application.
+    * Provider edits an existing event that they already contributed.
+    * Event re-enters review queue for admin users.
 
 
 ## GRASA and Monroe County staff
 
 ### Review and approve submitted events.
 
-* **Status**: Unconfirmed
-* **Technology decision**: [User authentication modules](https://docs.djangoproject.com/en/2.2/topics/auth/) provided in Django, [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/) for managing event data, [Django admin site](https://docs.djangoproject.com/en/2.2/ref/contrib/admin/) for interface to edit event data, email (via [Mailgun](https://www.mailgun.com/pricing))
+* **Status**: Implemented
+* **Technology decision**: [User authentication modules](https://docs.djangoproject.com/en/2.2/topics/auth/) provided in Django, [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/) for managing event data, email (via [Mailgun](https://www.mailgun.com/pricing))
 * **Relevant domain(s)**: Full stack
 * **Summary of approach**: A status field in the database will be edited for an event depending if it is pending review, approved, or rejected; only approved events appear on the public site.
 * **Completion criteria**:
-    * Admin is able to log into application
-    * Admin is able to edit a pending event and change its status (approved or rejected)
-    * Provider is emailed when their event status is changed
-    * Admin can note a reason why an event is rejected
+    * Admin is able to log into application.
+    * Admin is able to edit a pending event and change its status (approved or rejected).
+    * Provider is emailed when their event status is changed.
 
 ### Confirm new provider accounts.
 
-* **Status**: Confirmed
+* **Status**: Implemented
 * **Technology decision**: [User authentication modules](https://docs.djangoproject.com/en/2.2/topics/auth/) provided in Django, email (via [Mailgun](https://www.mailgun.com/pricing))
 * **Relevant domain(s)**: Back-end, database
 * **Summary of approach**: Allow anyone to self-register on the website using Django Forms to gather information about the user and saving the User object to the database when registration process completes.
 * **Completion criteria**:
-    * Admin is able to log into application
-    * Registered user is able to log in as a provider once admin confirms user's registration
+    * Admin is able to log into application.
+    * Registered user is able to log in as a provider once admin confirms user's registration.
 
 
 ## All users
 
 ### Mobile-friendly user interface.
 
-* **Status**: Skipped
+* **Status**: Implemented
 * **Relevant domain(s)**: Front-end
 * **Summary of approach**: Ensure web application appears correctly on modern smartphones and mobile devices by manual QA testing.
 * **Completion criteria**:
-    * Core functionality works smoothly on mobile device as it does computing device
+    * Core functionality works smoothly on mobile device as it does computing device.

--- a/docs/howto/add-dependencies.md
+++ b/docs/howto/add-dependencies.md
@@ -1,5 +1,5 @@
-How to: Add new dependencies / libraries?
-=========================================
+How to: Add new dependencies / libraries
+========================================
 
 If we use a new library or framework, we need to **install it as a dependency** in the project.
 Dependencies are specific versions of third-party software we want to use in the project.
@@ -55,10 +55,10 @@ The second command updates the `Pipfile.lock` file with your changes and ensures
 
 ### When testing dependencies, should `pip` or `pip3` be run?
 
-If in doubt, use them exactly as written in the step.
+If in doubt, use them exactly as written above.
 
-When you install `pipenv`, this guide assumes you are running Python 3 on your base operating system.
+When you install `pipenv`, this guide assumes you are running Python 3.
 `pip3` is an explicit process call to your system's installed Python 3 interpreter.
-If you do not have Python 2 installed, `pip` probably works the same too.
+If you do not have Python 2 installed, `pip` probably does the same thing.
 Later, after opening a `pipenv shell`, the Python virtualenv rewrites the meaning of `pip` to whatever the specified `python_version` is in `Pipfile`.
 So long as you are in the shell, `pip` will _always_ mean the same thing as `pip3`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,19 +16,19 @@ For more information, see the `repo on GitHub <https://github.com/jwflory/django
 
 .. toctree::
     :maxdepth: 2
-    :name: howto
-    :caption: Howto articles
-    :glob:
-
-    howto/*
-
-.. toctree::
-    :maxdepth: 2
     :name: development
-    :caption: Development
+    :caption: Development:
     :glob:
 
     dev/*
+
+.. toctree::
+    :maxdepth: 2
+    :name: howto
+    :caption: How-to knowledgebase:
+    :glob:
+
+    howto/*
 
 
 ******************


### PR DESCRIPTION
This pull request includes various improvements and fixes to the docs. See the full commit messages for more details:

*  **docs: Move "Add deps" doc to howto section (from dev docs)** — 80c9306
* **docs/about-project: Refactor for clarity, remove outdated info** — e26fe1c
* **docs/index: Sort dev docs above how-to articles** — 434c88f
* **docs: Update "Features" page for current development status** — db9c446 