### PR TITLE
Email functionality / Username change

### DIFF
--- a/grasa_event_locator/functions.py
+++ b/grasa_event_locator/functions.py
@@ -12,6 +12,17 @@ def send_email(address, subject, message):
     )
     return i
 
+def change_username(old_email, new_email, request):
+    old_email = request.user.username
+    request.user.username = request.POST['changeemail']
+    request.user.save()
+    request.user.email = request.POST['changeemail']
+    request.user.save()
+    new_email = request.user.username
+    send_email([old_email, new_email], "GRASA - Email Changed",
+               "The email for the " + request.user.userinfo.org_name + " account has changed from " + old_email + " to " + new_email + ". This email is being sent as a notification to both addresses.")
+    return 0
+
 def write_categories_table():
     with connection.cursor() as cursor:
         cursor.execute("delete from grasa_event_locator_program_categories")

--- a/grasa_event_locator/templates/admin.php
+++ b/grasa_event_locator/templates/admin.php
@@ -31,12 +31,11 @@
                              </h5>
                         </span>
                         <!-- edit email-->
-                        <form>
-                            
+                        <form method="POST" action="admin.php">{% csrf_token %}
                              <div class="input-group mb-3 changeEmailInput">
-                                <input type="text" class="form-control" placeholder="{{ user }}" aria-label="{{ user }}" value="{{ user }}" name="changeemail">
+                                <input type="text" name="changeemail" class="form-control" placeholder="{{ user }}" aria-label="{{ user }}" value="{{ user }}">
                               <div class="input-group-append">
-                                <button class="btn btn-outline-primary changeEmailSave" type="button" id="button-addon2">Save</button>
+                                <button type="submit" class="btn btn-outline-primary changeEmailSave" id="button-addon2">Save</button>
                               </div>
                             </div>
                         </form>

--- a/grasa_event_locator/templates/allAdmins.php
+++ b/grasa_event_locator/templates/allAdmins.php
@@ -60,7 +60,7 @@
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-    <form id="theForm" class="needs-validation" novalidate>
+    <form method="POST" action="allAdmins.php" id="theForm" class="needs-validation" novalidate>{% csrf_token %}
       <div class="modal-body">
 
         <div class="row">
@@ -101,7 +101,7 @@
 
             </div>
         </div>
-      </div> 
+      </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-danger" data-dismiss="modal">Cancel</button>
         <button type="submit" class="btn btn-success" value="Submit">Create Admin</button>

--- a/grasa_event_locator/templates/allUsers.php
+++ b/grasa_event_locator/templates/allUsers.php
@@ -71,14 +71,14 @@
         </button>
       </div>
       <div class="modal-body">
-          <form>
-      <div class="form-group">
-        <label for="exampleInputEmail1">Send an email to an organization you would like to invite as a provider:</label>
-        <input type="email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp" placeholder="Enter Email...">
-      </div>
-              <div class="twentyblock"></div>
-       <button type="submit" class="btn btn-primary w-100">Send Invite</button>
-    </form>
+          <form method="post" action="allUsers.php">{% csrf_token %}
+              <div class="form-group">
+                <label for="exampleInputEmail1">Send an email to an organization you would like to invite as a provider:</label>
+                <input type="email" name="emailAddr" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp" placeholder="Enter Email...">
+              </div>
+                      <div class="twentyblock"></div>
+               <button type="submit" class="btn btn-primary w-100">Send Invite</button>
+          </form>
       </div>
     </div>
   </div>

--- a/grasa_event_locator/templates/provider.php
+++ b/grasa_event_locator/templates/provider.php
@@ -38,7 +38,7 @@
                         <form action="provider.php" method="post">
                             {% csrf_token %}
                              <div class="input-group mb-3 changeNameInput">
-                                <input type="text" class="form-control" placeholder="{{ user.userinfo.org_name }}" aria-label="{{ user.userinfo.org_name }}" value="{{ user.userinfo.org_name }}" name="changename">
+                                <input type="text" name="changename" class="form-control" placeholder="{{ user.userinfo.org_name }}" aria-label="{{ user.userinfo.org_name }}" value="{{ user.userinfo.org_name }}" name="changename">
                               <div class="input-group-append">
                                 <button class="btn btn-outline-primary changeNameSave" type="submit" id="button-addon2">Save</button>
                               </div>
@@ -51,12 +51,11 @@
                              </h5>
                         </span>
                         <!-- edit email-->
-                        <form>
-                            
+                        <form method="POST" action="provider.php">{% csrf_token %}
                              <div class="input-group mb-3 changeEmailInput">
-                                <input type="text" class="form-control" placeholder="{{ user }}" aria-label="{{ user }}" value="{{ user }}" name="changeemail">
+                                <input type="text" name="changeemail" class="form-control" placeholder="{{ user }}" aria-label="{{ user }}" value="{{ user }}">
                               <div class="input-group-append">
-                                <button class="btn btn-outline-primary changeEmailSave" type="button" id="button-addon2">Save</button>
+                                <button class="btn btn-outline-primary changeEmailSave" type="submit" id="button-addon2">Save</button>
                               </div>
                             </div>
                         </form>

--- a/grasa_event_locator/templates/provider.php
+++ b/grasa_event_locator/templates/provider.php
@@ -38,7 +38,7 @@
                         <form action="provider.php" method="post">
                             {% csrf_token %}
                              <div class="input-group mb-3 changeNameInput">
-                                <input type="text" name="changename" class="form-control" placeholder="{{ user.userinfo.org_name }}" aria-label="{{ user.userinfo.org_name }}" value="{{ user.userinfo.org_name }}" name="changename">
+                                <input type="text" name="changename" class="form-control" placeholder="{{ user.userinfo.org_name }}" aria-label="{{ user.userinfo.org_name }}" value="{{ user.userinfo.org_name }}">
                               <div class="input-group-append">
                                 <button class="btn btn-outline-primary changeNameSave" type="submit" id="button-addon2">Save</button>
                               </div>

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -347,7 +347,7 @@ def denyEvent(request, eventID):
         if request.user.is_authenticated and request.user.userinfo.isAdmin and request.user.userinfo.isActive:
                 p = Program.objects.get(pk=eventID)
                 p.delete()
-                print(send_email([str(User.objects.get(pk=p.user_id.user_id))], "GRASA - Event Denied", "Your edited event has been denied. Contact GRASA for details."))
+                print(send_email([str(User.objects.get(pk=p.user_id.user_id))], "GRASA - Event Denied", "Your event has been denied. Contact GRASA for details."))
                 return redirect("admin_page")
         else:
                 return redirect("login_page")

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -236,8 +236,9 @@ def provider(request):
                         change_username(request.user.username, request.POST['changeemail'] , request)
                         return render(request, 'provider.php')
                 if request.POST.get('changename'):
-                        with connection.cursor() as cursor:
-                                cursor.execute("UPDATE `grasa_event_locator_userinfo` SET `org_name` = '" + request.POST['changename'] + "' WHERE `org_name` = '" + request.user.userinfo.org_name + "';")
+                        u = userInfo.objects.get(pk=request.user.id)
+                        u.org_name = request.POST['changename']
+                        u.save()
                         return render(request, 'provider.php')
         if request.user.is_authenticated and not request.user.userinfo.isAdmin and request.user.userinfo.isActive:
                 currentUser = userInfo.objects.filter(user=(request.user.userinfo.id - 1))

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -25,14 +25,13 @@ def aboutContact(request):
         return render(request, 'aboutContact.php')
 
 def admin(request):
-
         if request.user.is_authenticated and request.user.userinfo.isAdmin and request.user.userinfo.isActive:
                 pendingUserList = userInfo.objects.filter(isPending=True)
                 pendingEventList = Program.objects.filter(isPending=True).filter(editOf=0)
                 pendingEditList = Program.objects.filter(isPending=True).exclude(editOf=0)
-
                 context = {'pendingUserList' : pendingUserList, 'pendingEventList' : pendingEventList, 'pendingEditList' : pendingEditList}
-
+                if request.method == "POST":
+                        change_username(request.user.username, request.POST['changeemail'] , request)
                 return render(request, "admin.php", context)
         if request.user.is_authenticated and request.user.userinfo.isAdmin == 0 and request.user.userinfo.isActive:
                 return HttpResponseRedirect('provider.php')
@@ -62,16 +61,15 @@ def create_database(request):
 def allUsers(request):
         userList = userInfo.objects.filter(isActive=True).filter(isAdmin=False)
         context = {'userList': userList}
+
+        if request.method == 'POST':
+                print(send_email([request.POST.get('emailAddr')], "GRASA - Event Locator Registration", "You've been invited to sign up for the GRASA Event Locator! Register at http://grasa.larrimore.de/register.php"))
         return render(request, 'allUsers.php', context)
 
 def allAdmins(request):
         userList = userInfo.objects.filter(isAdmin=True)
         context = {'userList': userList}
-
         if request.method == 'POST' and request.POST['confirm'] == request.POST['confirm']:
-                print(request.POST['emailAddr'])
-                print(request.POST['current'])
-                print(request.POST['confirm'])
                 emailAddr = request.POST['emailAddr']
                 current = request.POST['current']
                 newUser = UserAccount.objects.create_user(emailAddr, emailAddr, current)
@@ -81,6 +79,7 @@ def allAdmins(request):
                         cursor.execute("UPDATE `grasa_event_locator_userinfo` SET `isAdmin` = '1' WHERE `grasa_event_locator_userinfo`.`org_name` = 'Administrator';")
                         cursor.execute("UPDATE `grasa_event_locator_userinfo` SET `isPending` = '0' WHERE `grasa_event_locator_userinfo`.`org_name` = 'Administrator';")
                         cursor.execute("UPDATE `grasa_event_locator_userinfo` SET `isActive` = '1' WHERE `grasa_event_locator_userinfo`.`org_name` = 'Administrator';")
+                print(send_email([emailAddr], "GRASA - Administrator Account Created", "You've now been designated an Administrator at the GRASA Event Locator! Please consult GRASA for login information, if you have not already received it."))
                 return redirect("allAdmins.php")
                 #return render(request, 'login.php')
         else:
@@ -233,9 +232,13 @@ def index(request):
 
 def provider(request):
         if request.method == 'POST':
-                 with connection.cursor() as cursor:
-                        cursor.execute("UPDATE `grasa_event_locator_userinfo` SET `org_name` = '" + request.POST['changename'] + "' WHERE `org_name` = '" + request.user.userinfo.org_name + "';")
-                 return render(request, 'provider.php', )
+                if request.POST.get('changeemail'):
+                        change_username(request.user.username, request.POST['changeemail'] , request)
+                        return render(request, 'provider.php')
+                if request.POST.get('changename'):
+                        with connection.cursor() as cursor:
+                                cursor.execute("UPDATE `grasa_event_locator_userinfo` SET `org_name` = '" + request.POST['changename'] + "' WHERE `org_name` = '" + request.user.userinfo.org_name + "';")
+                        return render(request, 'provider.php')
         if request.user.is_authenticated and not request.user.userinfo.isAdmin and request.user.userinfo.isActive:
                 currentUser = userInfo.objects.filter(user=(request.user.userinfo.id - 1))
                 myEventList = Program.objects.filter(user_id = request.user.userinfo.id)
@@ -281,7 +284,7 @@ def resetpw(request):
                         resetPWURL = resetPWURLs(user_ID = request.POST['emailAddr'], reset_string= resetlink)
                         resetPWURL.save()
                         # Make sure to pull the hostname from config file.
-                        print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "Link at http://grasa.larrimore.de/changePWLogout/" + resetlink))
+                        print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "You've requested a password reset at the GRASA Event Locator. Please visit this linnk: http://grasa.larrimore.de/changePWLogout/" + resetlink))
 
         return render(request, 'resetPW.php')
 
@@ -309,6 +312,7 @@ def approveUser(request, userID):
                 u.isPending = False
                 u.isActive = True
                 u.save()
+                print(send_email([u.contact_email], "GRASA - Alternate Contact", "You are the alternative contact for " + u.org_name + " in the GRASA Event Locator. Please contact them for further details."))
                 return redirect("admin_page")
         else:
                 return redirect("login_page")
@@ -332,9 +336,8 @@ def approveEvent(request, eventID):
                 p = Program.objects.get(pk=eventID)
                 p.isPending = False
                 p.save()
-
                 rebuildIndex.rebuildWhooshIndex()
-                
+                print(send_email([str(User.objects.get(pk=p.user_id.user_id))], "GRASA - Event Approved!", "Your event has been approved! See it at http://grasa.larrimore.de/event/" + str(p.id)))
                 return redirect("admin_page")
         else:
                 return redirect("login_page")
@@ -343,6 +346,7 @@ def denyEvent(request, eventID):
         if request.user.is_authenticated and request.user.userinfo.isAdmin and request.user.userinfo.isActive:
                 p = Program.objects.get(pk=eventID)
                 p.delete()
+                print(send_email([str(User.objects.get(pk=p.user_id.user_id))], "GRASA - Event Denied", "Your edited event has been denied. Contact GRASA for details."))
                 return redirect("admin_page")
         else:
                 return redirect("login_page")
@@ -356,6 +360,7 @@ def approveEdit(request, editID):
                 p.editOf = 0
                 p.isPending = False
                 p.save()
+                print(send_email([str(User.objects.get(pk=p.user_id.user_id))], "GRASA - Event Edit Approved!", "Your edited event has been approved! See it at http://grasa.larrimore.de/event/" + str(p.id)))
                 return redirect("admin_page")
         else:
                 return redirect("login_page")
@@ -364,6 +369,7 @@ def denyEdit(request, editID):
         if request.user.is_authenticated and request.user.userinfo.isAdmin and request.user.userinfo.isActive:
                 p = Program.objects.get(pk=editID)
                 p.delete()
+                print(send_email([str(User.objects.get(pk=p.user_id.user_id))], "GRASA - Event Edit Denied", "Your edited event has been denied. Contact GRASA for details."))
                 return redirect("admin_page")
         else:
                 return redirect("login_page")


### PR DESCRIPTION
This commit implements the email functionality requested in Slack, as well as implements the username change feature. This should handle #90 and #134.

functions.py: Moved the change username function to functions.py, saves us a couple lines of code in views.

admin.php: hooked up the change username form to the backend.

allAdmins: Hooked up the create admin form to the backend.

allusers: Hooked up the invite provider form to the backend.

provider: hooked up the change email form to the backend.

views: Added all calls to send_email to send emails in the situations specified in Slack.