### PR TITLE
'All' Pages all done + bug fixes

### DIFF
--- a/grasa_event_locator/forms.py
+++ b/grasa_event_locator/forms.py
@@ -28,7 +28,7 @@ activityList = [
     ("Tutoring", "Tutoring"),
     ("Other", "Other"),
 ]
-transportationList = [("Provided", "Provided"), ("Not-Provided", "Not-Provided")]
+transportationList = [("Provided", "Provided")]
 gradesList = [
     ("K-3rd", "K-3rd"),
     ("K-5th", "K-5th"),
@@ -39,7 +39,6 @@ gradesList = [
 genderList = [
     ("Male-Only", "Male-Only"),
     ("Female-Only", "Female-Only"),
-    ("Non-Specific", "Non-Specific"),
 ]
 feesList = [
     ("Free", "Free"),
@@ -162,7 +161,6 @@ class grasaSearchForm(SearchForm):
                 if gender[0] == selectedGender:
                     sqs = sqs.filter(content=gender[0])
 
-        # Needs changes
         selectedFees = self.cleaned_data["fees"]
         for selectedFee in selectedFees:
             # These need to be specially written since they aren't stored as a range in the DB

--- a/grasa_event_locator/functions.py
+++ b/grasa_event_locator/functions.py
@@ -65,9 +65,6 @@ def write_categories_table():
     table.save()
     table = Category(description="Other")
     table.save()
-    # Refactored to match header and forms as well as fix duplicate search bug
-    table = Category(description="Not-Provided")
-    table.save()
     table = Category(description="Provided")
     table.save()
     table = Category(description="K-3rd")
@@ -79,9 +76,6 @@ def write_categories_table():
     table = Category(description="6th-8th")
     table.save()
     table = Category(description="9th-12th")
-    table.save()
-    # Refactored to match header and forms
-    table = Category(description="Non-Specific")
     table.save()
     # Refactored to match header and forms as well as fix duplicate search bug
     table = Category(description="Female-Only")

--- a/grasa_event_locator/models.py
+++ b/grasa_event_locator/models.py
@@ -6,7 +6,6 @@ class userInfo(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     org_name = models.CharField(max_length=255)
     isAdmin = models.BooleanField(default=False)
-    isActive = models.BooleanField(default=False)
     isPending = models.BooleanField(default=True)
     contact_name = models.CharField(max_length=255, default="Name not Specified")
     contact_phone = models.CharField(max_length=255, default="Phone Number not Specified")

--- a/grasa_event_locator/templates/allAdmins.php
+++ b/grasa_event_locator/templates/allAdmins.php
@@ -3,6 +3,11 @@
     <div class="col-sm-12">
         <div class="twentyblock"></div>
         <h2 class="text-center">All Admins</h2>
+        {% if emailTaken %}
+        <div class="alert alert-warning" role="alert">
+          An account has already been registered with this email address, please use another.
+        </div>
+        {% endif %}
         <button type="button" class="btn btn-info float-left" style="margin-bottom: 10px;" id="backBtn"> <i class="fa fa-chevron-left" aria-hidden="true" ></i> Back to Admin Portal</button>
         
         <button type="button" class="btn btn-success float-right" id="addAdmin" data-toggle="modal" data-target="#addadminModal"><i class="fa fa-user-plus" aria-hidden="true"></i> Add Admin</button>

--- a/grasa_event_locator/templates/allEvents.php
+++ b/grasa_event_locator/templates/allEvents.php
@@ -11,22 +11,23 @@
                 <tr>
                   <th scope="col">Name</th>
                   <th scope="col">Organization</th>
-                  <th scope="col">Date Created</th>
+                  <th scope="col">Created By</th>
                   <th scope="col" class="list-header-fix">View</th>
                   <th scope="col" class="list-header-fix">Delete</th>
                 </tr>
               </thead>
               <tbody class="provider-program-list">
+                {% for p in programList %}
                 <tr>
-                  <td>Put Name Here</td>
-                  <td>Put Org Here</td>
-                  <td>Put Date Here</td>
-                  <td><button type="button" class="btn btn-outline-info">View</button></td>
-                  <td><button type="button" class="btn btn-outline-danger" data-toggle="modal" data-target="#deleteModal">Delete</button></td>
+                  <td>{{ p.title }}</td>
+                  <td>{{ p.user_id.org_name }}</td>
+                  <td>{{ p.user_id.user.username }}</td>
+                  <td><button type="button" class="btn btn-outline-info" onclick="window.location.href='{% url 'event_page' p.id %}'">View</button></td>
+                  <td><button type="button" class="btn btn-outline-danger" data-toggle="modal" data-target="#deleteModal{{ p.id }}">Delete</button></td>
                 </tr>
 
                 <!--Delete Modal-->
-                <div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                <div class="modal fade" id="deleteModal{{ p.id }}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
                   <div class="modal-dialog" role="document">
                     <div class="modal-content">
                       <div class="modal-header">
@@ -40,14 +41,14 @@
                       </div>
                       <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-dismiss="modal">Never Mind</button>
-                        <button type="button" class="btn btn-danger" data-dismiss="modal" onclick="">Confirm Delete</button>
+                        <button type="button" class="btn btn-danger" data-dismiss="modal" onclick="window.location.href='{% url 'deny_event' p.id %}'">Confirm Delete</button>
 
                       </div>
                     </div>
                   </div>
                 </div>
                 
-
+                {% endfor %}
               </tbody>
             </table>
     </div>

--- a/grasa_event_locator/templates/allUsers.php
+++ b/grasa_event_locator/templates/allUsers.php
@@ -28,7 +28,7 @@
                     
                     </td>
 
-                  <td> TBD </td>
+                  <td>{{ user.program_set.count }} </td>
                   <!--Set target to correct modal so it deletes the correct user-->
                   <td><button type="button" class="btn btn-outline-danger" data-toggle="modal" data-target="#deleteModal{{ user.id }}">Delete</button></td>
                 </tr>

--- a/grasa_event_locator/templates/editEvent.php
+++ b/grasa_event_locator/templates/editEvent.php
@@ -263,7 +263,7 @@
     //Cancel Button and Ok Button returns to provider page
     var cancelBtn = document.getElementById('cancelBtn');
     cancelBtn.onclick = function(){
-        window.location = 'provider.php'
+        window.location = '/provider.php'
     }
     var okBtn = document.getElementById('submitOkBtn');
     okBtn.onclick = function(){

--- a/grasa_event_locator/templates/event.php
+++ b/grasa_event_locator/templates/event.php
@@ -24,7 +24,7 @@
               <img src="https://via.placeholder.com/150" class="card-img-top" alt="Provider Logo">
               <ul class="list-group list-group-flush">
                 {% if event.fees %}
-                <li class="list-group-item"><i class="fa fa-money fa-fw" aria-hidden="true"></i> ${{ event.fees }}</li>
+                <li class="list-group-item"><i class="fa fa-money fa-fw" aria-hidden="true"></i> ${{ fees }}</li>
                 {% else %}
                 <li class="list-group-item"><i class="fa fa-money fa-fw" aria-hidden="true"></i> Not Provided </li>
                 {% endif %}

--- a/grasa_event_locator/templates/header.php
+++ b/grasa_event_locator/templates/header.php
@@ -44,17 +44,17 @@
 
         //Transportation
         //Refactored to match header and forms as well as fix duplicate search bug
-        var transportationList = ["Provided", "Not-Provided"]
+        var transportationList = ["Provided"]
 
         //Grades Served
         var gradesList = ["K-3rd", "K-5th", "3rd-5th", "6th-8th", "9th-12th"]
 
         //Gender
         //Refactored to match header and forms as well as fix duplicate search bug
-        var genderList = ["Male-Only", "Female-Only", "Non-Specific"]
+        var genderList = ["Male-Only", "Female-Only"]
 
         //Distance
-        var distanceList = ["0-5 miles", "6-10 miles", "11-15 miles", "16-20 miles", "20+ miles"]
+        //var distanceList = ["0-5 miles", "6-10 miles", "11-15 miles", "16-20 miles", "20+ miles"]
 
         //Fees
         var feesList = ["Free", "$1-$25", "$26-$50", "$51-$75", "$75+"]

--- a/grasa_event_locator/templates/provider.php
+++ b/grasa_event_locator/templates/provider.php
@@ -129,15 +129,15 @@
               {% if myEvent.isPending == 1 %}
                 <td><a href="{% url 'event_page' myEvent.id %}"><button type="button" class="btn btn-outline-info view-event" disabled>View</button></a></td>
                 <td><a href="{% url 'edit_page' myEvent.id %}"><button type="button" class="btn btn-outline-info editBtn" disabled>Edit</button></a></td>
-                <td><button type="button" class="btn btn-outline-danger" data-toggle="modal" data-target="#deleteModal" >Delete</button></td> 
+                <td><button type="button" class="btn btn-outline-danger" data-toggle="modal" data-target="#deleteModal{{ myEvent.id }}" >Delete</button></td> 
               {% else %}
               
               <td><a href="{% url 'event_page' myEvent.id %}"><button type="button" class="btn btn-outline-info view-event">View</button></a></td>
               <td><a href="{% url 'edit_page' myEvent.id %}"><button type="button" class="btn btn-outline-info editBtn">Edit</button></a></td>
-              <td><button type="button" class="btn btn-outline-danger"  data-toggle="modal" data-target="#deleteModal">Delete</button></td>
+              <td><button type="button" class="btn btn-outline-danger"  data-toggle="modal" data-target="#deleteModal{{ myEvent.id }}">Delete</button></td>
               {% endif %}
               <!--Delete Modal-->
-                <div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel3" aria-hidden="true">
+                <div class="modal fade" id="deleteModal{{ myEvent.id }}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel3" aria-hidden="true">
                   <div class="modal-dialog" role="document">
                     <div class="modal-content">
                       <div class="modal-header">
@@ -151,7 +151,7 @@
                       </div>
                       <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-dismiss="modal">Never Mind</button>
-                        <button type="button" class="btn btn-danger" data-dismiss="modal" onclick="">Confirm Delete</button>
+                        <button type="button" class="btn btn-danger" data-dismiss="modal" onclick="window.location.href='{% url 'deny_event' myEvent.id %}'">Confirm Delete</button>
 
                       </div>
                     </div>

--- a/grasa_event_locator/templates/search/search.html
+++ b/grasa_event_locator/templates/search/search.html
@@ -115,16 +115,16 @@
                         </div>
                     </div>
                 </div>
-                <div class="card">
+                <!-- <div class="card">
                     <div class="card-header" id="headingDistance">
                         <h2 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseDistance" aria-expanded="true" aria="" controls="collapseDistance">Distance</button></h2></div>
                     <div id="collapseDistance" class="collapse" data-parent="#accordionExample">
                         <div class="card-body">
                             <input class="form-control form-control-sm distance-input" type="text" placeholder="From Address...">
-                            <!--put distance here-->
+                            <!-/-put distance here-/->
                         </div>
                     </div>
-                </div>
+                </div> -->
                 <div class="card">
                     <div class="card-header" id="headingFees">
                         <h2 class="mb-0"><button class="btn btn-link collapsed" type="button" data-toggle="collapse" data-target="#collapseFees" aria-expanded="true" aria="" controls="collapseFees">Fees</button></h2></div>

--- a/grasa_event_locator/urls.py
+++ b/grasa_event_locator/urls.py
@@ -8,7 +8,6 @@ from django.contrib import admin
 urlpatterns = [
     path('aboutContact.php', views.aboutContact),
     path('admin.php', views.admin, name='admin_page'),
-    path('admin_activate', views.admin_activate),
     path('create_database', views.create_database),
     path('allUsers.php', views.allUsers),
     path('allAdmins.php', views.allAdmins),

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -40,7 +40,12 @@ def admin(request):
         return render(request, 'admin.php')
 
 def admin_user(request):
-        newUser = UserAccount.objects.create_user("grasatest@yahoo.com", "grasatest@yahoo.com", "Password1")
+        newUser = UserAccount.objects.create_superuser("grasatest@yahoo.com", "grasatest@yahoo.com", "Password1")
+        newUser.save()
+        newUser.isStaff = True
+        newUser.save()
+        newUser.is_admin = True
+        newUser.save()
         uInfo = userInfo(user=newUser, org_name="Administrator", isAdmin=True, isPending=False)
         uInfo.save()
         return HttpResponseRedirect("index.php")
@@ -71,7 +76,7 @@ def allAdmins(request):
                 return render(request, 'allAdmins.php', context)
             else:
                 current = request.POST['current']
-                newUser = UserAccount.objects.create_user(emailAddr, emailAddr, current)
+                newUser = UserAccount.objects.create_superuser(emailAddr, emailAddr, current)
                 uInfo = userInfo(user=newUser, org_name="Administrator", isAdmin=True, isPending=False)
                 uInfo.save()
                 print(send_email([emailAddr], "GRASA - Administrator Account Created", "You've now been designated an Administrator at the GRASA Event Locator! Please consult GRASA for login information, if you have not already received it."))
@@ -324,10 +329,12 @@ def approveUser(request, userID):
 def denyUser(request, userID):
         if request.user.is_authenticated and request.user.userinfo.isAdmin and not request.user.userinfo.isPending:
                 u = userInfo.objects.get(pk=userID)
+                v = User.objects.get(id = userID)
                 #for program in u.program_set.all():
                 #    program.delete()
                 #^^^^^works but breaks page unless rebuild_index run
                 u.delete()
+                v.delete()
                 rebuildIndex.rebuildWhooshIndex()
                 return redirect("admin_page")
         else:


### PR DESCRIPTION
- Added duplicate entry checks and feedback for add admin
- Removed isActive, non-specific gender,  not-provided, and distance filter
- Made delete in allUsers work, deletes user and all their events, then rebuilds index
- Hooked up allEvents page and set delete event to rebuild index
- Added security to all 'all' pages
- Added number of events to all providers
- Fixed bug where providers could not delete their events from provider.php
- Fixed bug where changing name in provider would cause events to not show up until reload
- Fixed bug where cancelling an event edit would cause a page break
- Fixed bug where fees would appear to 1 decimal point instead of 2