### PR TITLE
Sync user_id with id.

### DIFF
--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -282,13 +282,11 @@ def register(request):
                     newUser = UserAccount.objects.create_user(emailAddr, emailAddr, current)
                     uInfo = userInfo(user = newUser, org_name = orgName, contact_name = contact_name, contact_email = contact_email, contact_phone = contact_phone)
                     uInfo.save()
-                    try:
-                        if int(uInfo.id) != int(uInfo.user_id):
-                            uInfo.id = int(uInfo.user_id)
-                            uInfo.save()
-                    except IntegrityError:
-                        return redirect("login_page")
-                    return redirect("login_page")
+                    if int(uInfo.id) != int(uInfo.user_id):
+                        uInfo.delete()
+                        uInfo2 = userInfo(pk=int(uInfo.user_id),user=newUser, org_name=orgName, contact_name=contact_name, contact_email=contact_email, contact_phone=contact_phone)
+                        uInfo2.save()
+                return redirect("login_page")
         else:
                 context = {'emailTaken' : False}
                 return render(request, 'register.php', context)

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -49,6 +49,10 @@ def admin_user(request):
         newUser.save()
         uInfo = userInfo(user=newUser, org_name="Administrator", isAdmin=True, isPending=False)
         uInfo.save()
+        if int(uInfo.id) != int(uInfo.user_id):
+            uInfo2 = userInfo(pk=int(uInfo.user_id), user=newUser, org_name="Administrator", isAdmin=True, isPending=False)
+            uInfo.delete()
+            uInfo2.save()
         return HttpResponseRedirect("index.php")
 
 def create_database(request):
@@ -283,8 +287,8 @@ def register(request):
                     uInfo = userInfo(user = newUser, org_name = orgName, contact_name = contact_name, contact_email = contact_email, contact_phone = contact_phone)
                     uInfo.save()
                     if int(uInfo.id) != int(uInfo.user_id):
-                        uInfo.delete()
                         uInfo2 = userInfo(pk=int(uInfo.user_id),user=newUser, org_name=orgName, contact_name=contact_name, contact_email=contact_email, contact_phone=contact_phone)
+                        uInfo.delete()
                         uInfo2.save()
                 return redirect("login_page")
         else:

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -282,6 +282,12 @@ def register(request):
                     newUser = UserAccount.objects.create_user(emailAddr, emailAddr, current)
                     uInfo = userInfo(user = newUser, org_name = orgName, contact_name = contact_name, contact_email = contact_email, contact_phone = contact_phone)
                     uInfo.save()
+                    try:
+                        if int(uInfo.id) != int(uInfo.user_id):
+                            uInfo.id = int(uInfo.user_id)
+                            uInfo.save()
+                    except IntegrityError:
+                        return redirect("login_page")
                     return redirect("login_page")
         else:
                 context = {'emailTaken' : False}


### PR DESCRIPTION
This patches up an issue regarding logins, occasionally the id and user_id of the tables would go out of sync for one reason or another, preventing a login from successfully happening. This checks that the user_id (which should always be accurate) matches the userinfo table's primary key at registration, if not, a new entry is created with the correct primary key, and the old entry is deleted.