### PR TITLE
settings: Test production settings for final deployment

### DIFF
--- a/grasa_event_locator/settings/base.py
+++ b/grasa_event_locator/settings/base.py
@@ -186,6 +186,16 @@ LOGGING = {
     }
 }
 
+
+# HAYSTACK
+HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+        'PATH': os.path.join(os.path.dirname(__file__), 'whoosh_index'),
+    },
+}
+
+
 EMAIL_HOST = "smtp.mail.yahoo.com"
 EMAIL_USE_SSL = True
 EMAIL_PORT = 465

--- a/grasa_event_locator/settings/development.py
+++ b/grasa_event_locator/settings/development.py
@@ -105,13 +105,6 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-HAYSTACK_CONNECTIONS = {
-    'default': {
-        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
-        'PATH': os.path.join(os.path.dirname(__file__), 'whoosh_index'),
-    },
-}
-
 try:
     from local_settings import * # noqa
 except ImportError:

--- a/grasa_event_locator/settings/production.py
+++ b/grasa_event_locator/settings/production.py
@@ -22,10 +22,10 @@ ADMINS = (
 )
 MANAGERS = ADMINS
 
-# DJANGO-COMPRESSOR SETTINGS
-STATICFILES_FINDERS = STATICFILES_FINDERS + (
-    'compressor.finders.CompressorFinder',
-)
+## DJANGO-COMPRESSOR SETTINGS
+#STATICFILES_FINDERS = STATICFILES_FINDERS + (
+#    'compressor.finders.CompressorFinder',
+#)
 
 try:
     from local_settings import * # noqa


### PR DESCRIPTION
This commit came from some real-life testing @nlMeminger and I did
together when we ran `python3 manage.py runserver --settings`
`grasa_event_locator.settings.production`. This runs the app with the
production settings file, without debug options enabled.

Some more work is needed for this. It is related to #157.