### PR TITLE
views: Use reverse() for homepage redirects

### DIFF
--- a/grasa_event_locator/urls.py
+++ b/grasa_event_locator/urls.py
@@ -32,8 +32,6 @@ urlpatterns = [
     path('approve_edit/<editID>', views.approveEdit, name='approve_edit'),
     path('deny_edit/<editID>', views.denyEdit, name='deny_edit'),
     path('changePWLogout/<reset_string>', views.changePWLogout, name='changePW_logout'),
-    #path('search/', include('haystack.urls')),
-    url(r'^search//?$', views.programSearchView.as_view(), name='haystack_search'),
-    #path('search/', views.programSearchView.as_view(), name='haystack_search'),
+    url(r'^search//?$', views.programSearchView.as_view(), name='search'),
 ]
 

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -49,11 +49,11 @@ def admin_user(request):
         newUser.save()
         uInfo = userInfo(user=newUser, org_name="Administrator", isAdmin=True, isPending=False)
         uInfo.save()
-        return HttpResponseRedirect("index.php")
+        return HttpResponseRedirect(reverse('search'))
 
 def create_database(request):
         write_categories_table()
-        return HttpResponseRedirect("index.php")
+        return HttpResponseRedirect(reverse('search'))
 
 def allUsers(request):
     if request.user.is_authenticated and request.user.userinfo.isAdmin and not request.user.userinfo.isPending:
@@ -63,7 +63,7 @@ def allUsers(request):
         if request.method == 'POST':
                 print(send_email([request.POST.get('emailAddr')], "GRASA - Event Locator Registration", "You've been invited to sign up for the GRASA Event Locator! Register at http://grasa.larrimore.de/register.php"))
         return render(request, 'allUsers.php', context)
-    return HttpResponseRedirect("index.php")
+    return HttpResponseRedirect(reverse('search'))
 
 def allAdmins(request):
     if request.user.is_authenticated and request.user.userinfo.isAdmin and not request.user.userinfo.isPending:
@@ -91,14 +91,14 @@ def allAdmins(request):
                 context = {'userList': userList, 'emailTaken' : False}
                 return render(request, 'allAdmins.php', context)
         return render(request, 'allAdmins.php', context)
-    return HttpResponseRedirect("index.php")
+    return HttpResponseRedirect(reverse('search'))
 
 def allEvents(request):
     if request.user.is_authenticated and request.user.userinfo.isAdmin and not request.user.userinfo.isPending:
         programList = Program.objects.filter(isPending=False)
         context = {'programList': programList}
         return render(request, 'allEvents.php', context)
-    return HttpResponseRedirect("index.php")
+    return HttpResponseRedirect(reverse('search'))
 
 def changepw(request):
         if request.user.is_authenticated:
@@ -111,7 +111,7 @@ def changepw(request):
                     else:
                             print("No")
         else:
-            return HttpResponseRedirect("index.php")
+            return HttpResponseRedirect(reverse('search'))
         return render(request, 'changePW.php')
 
 def createevent(request):
@@ -206,7 +206,7 @@ def event(request, eventID):
 
 def login(request):
         if request.user.is_authenticated:
-                return HttpResponseRedirect(reverse('haystack_search'))
+                return HttpResponseRedirect(reverse('search'))
         if request.method == 'POST':
                         email = request.POST['email']
                         password = request.POST['password']
@@ -240,10 +240,10 @@ def login(request):
 
 def logout_view(request):
         logout(request)
-        return HttpResponseRedirect("index.php")
+        return HttpResponseRedirect(reverse('search'))
 
 def index(request):
-        return redirect("haystack_search")
+        return redirect('search')
 
 def provider(request):
         if request.method == 'POST':
@@ -345,7 +345,7 @@ def denyUser(request, userID):
         else:
                 return redirect("login_page")
 
-                
+
 def approveEvent(request, eventID):
         if request.user.is_authenticated and request.user.userinfo.isAdmin and not request.user.userinfo.isPending:
                 p = Program.objects.get(pk=eventID)


### PR DESCRIPTION
This commit changes our existing redirects in our application to make
consistent use of the `reverse()` method. This uses the `name` metadata
set in the `urls.py` file. When you call something like
`reverse('search')`, this instructs Django to return the correct URL
string for whatever page matching the `search` name in the `urls.py` is.

The benefit of doing this is we don't have to remember where to update
things like file names (part of issue #156). So whenever we do switch
over the file extensions, we won't have to update multiple places in our
code when we do.

Contributes to #156 but does not close it.