### PR TITLE
Replaced last login

### DIFF
--- a/grasa_event_locator/templates/allAdmins.php
+++ b/grasa_event_locator/templates/allAdmins.php
@@ -29,7 +29,7 @@
                 <tr>
                 {% for user in userList %}
                   <th scope="row"><a href="mailto:{{ user.user }}">{{ user.user }}</a></th>
-                  <th scope="row">{{ user.last_login }}</th>
+                  <th scope="row">{{ user.user.last_login }}</th>
                   <td><button type="button" class="btn btn-outline-danger" data-toggle="modal" data-target="#deleteModal">Delete</button></td>
                 </tr>
                 {% endfor %}

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -249,9 +249,6 @@ def login(request):
                             return render(request,'login.php', context)
                         if user is not None and not user.userinfo.isPending:
                                 auth_login(request, user)
-                                u = userInfo.objects.get(pk=request.user.id)
-                                u.last_login = str(datetime.now())[:-7]
-                                u.save()
                                 if request.user.userinfo.isAdmin:
                                         return HttpResponseRedirect("admin.php")
                                 else:


### PR DESCRIPTION
Last login value now uses the django user table instead of the user table's id. Users should be able to now log in if the pk id doesn't match the user_id.