### PR TITLE
Patch Create Admins Button

### DIFF
--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -41,6 +41,10 @@ def admin(request):
         return render(request, 'admin.php')
 
 def admin_user(request):
+    userList = userInfo.objects.filter(isAdmin=True)
+    if (userList):
+        return HttpResponseRedirect(reverse('search'))
+    else:
         newUser = UserAccount.objects.create_superuser("grasatest@yahoo.com", "grasatest@yahoo.com", "Password1")
         newUser.save()
         newUser.isStaff = True


### PR DESCRIPTION
This patches a function of the Create New Provider button, which advances the user_id counter, even if the admin user was not created. It now checks that an admin user exists first. If so, the process is aborted and the user is sent to the search page. If there are no admins, the admin is created like normal...and still gets to the search page, actually.