### PR TITLE
Fix various event editing bugs

### DIFF
--- a/grasa_event_locator/templates/admin.php
+++ b/grasa_event_locator/templates/admin.php
@@ -132,8 +132,8 @@
                       <td>{{ pendingEdit.user_id.org_name }}</td>
                       <td>Pending</td>
                       <td><a href="{% url 'event_page' pendingEdit.id %}"><button type="button" class="btn btn-outline-info view-event">View</button></a></td>
-                      <td><a href="{% url 'approve_event' pendingEdit.id %}"><button type="button" class="btn btn-outline-success">Approve</button></a></td>
-                      <td><a href="{% url 'deny_event' pendingEdit.id %}"><button type="button" class="btn btn-outline-danger">Deny</button></a></td>
+                      <td><a href="{% url 'approve_edit' pendingEdit.id %}"><button type="button" class="btn btn-outline-success">Approve</button></a></td>
+                      <td><a href="{% url 'deny_edit' pendingEdit.id %}"><button type="button" class="btn btn-outline-danger">Deny</button></a></td>
                     </tr>
                     {% endfor %}
                   </tbody>


### PR DESCRIPTION
- Edited admin.php so that the edited event's buttons pointed to the correct views.

- Added the logic to the editEvent view that was needed to actually create a new program row with editOf set

- Changed the way edit event approval works so that the original event remains with it's old id (so as to preserve links to its detail page)

- Changed deny edit so we don't delete the info needed to send the email before sending the email...