### PR TITLE
Reset PW / Email Notification

### DIFF
--- a/grasa_event_locator/templates/resetPW.html
+++ b/grasa_event_locator/templates/resetPW.html
@@ -3,6 +3,11 @@
 
   <div class="form-reset">
 	<h1 class="h3 mb-3 font-weight-normal text-center">Reset Password</h1>
+        {% if email_sent %}
+        <div class="alert alert-warning" role="alert">
+          If this email address is associated with a provider account, an email has been sent with a link to reset the password.
+        </div>
+        {% endif %}
 	<form action="resetPW.html" method="post">
 	{% csrf_token %}
 		<label for="resetPW" class="sr-only">Email address</label>

--- a/grasa_event_locator/templates/resetPW.html
+++ b/grasa_event_locator/templates/resetPW.html
@@ -3,7 +3,7 @@
 
   <div class="form-reset">
 	<h1 class="h3 mb-3 font-weight-normal text-center">Reset Password</h1>
-        {% if email_sent %}
+        {% if email_submitted %}
         <div class="alert alert-warning" role="alert">
           If this email address is associated with a provider account, an email will been sent with a link to reset the password.
         </div>

--- a/grasa_event_locator/templates/resetPW.html
+++ b/grasa_event_locator/templates/resetPW.html
@@ -3,11 +3,6 @@
 
   <div class="form-reset">
 	<h1 class="h3 mb-3 font-weight-normal text-center">Reset Password</h1>
-        {% if email_sent %}
-        <div class="alert alert-warning" role="alert">
-          If this email address is associated with a provider account, an email has been sent with a link to reset the password.
-        </div>
-        {% endif %}
 	<form action="resetPW.html" method="post">
 	{% csrf_token %}
 		<label for="resetPW" class="sr-only">Email address</label>

--- a/grasa_event_locator/templates/resetPW.html
+++ b/grasa_event_locator/templates/resetPW.html
@@ -5,7 +5,7 @@
 	<h1 class="h3 mb-3 font-weight-normal text-center">Reset Password</h1>
         {% if email_sent %}
         <div class="alert alert-warning" role="alert">
-          If this email address is associated with a provider account, an email has been sent with a link to reset the password.
+          If this email address is associated with a provider account, an email will been sent with a link to reset the password.
         </div>
         {% endif %}
 	<form action="resetPW.html" method="post">

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -376,7 +376,6 @@ def resetpw(request):
         i = 0
         if request.method == 'POST':
                 if User.objects.filter(username=request.POST['emailAddr']).exists():
-                        context = {'email_sent': True}
                         with connection.cursor() as cursor:
                                 cursor.execute("DELETE FROM `grasa_event_locator_resetpwurls` WHERE `user_ID` = '" + request.POST['emailAddr'] + "';")
                         resetlink = ''.join([random.choice(string.ascii_letters + string.digits) for n in range(15)])
@@ -384,8 +383,8 @@ def resetpw(request):
                         resetPWURL.save()
                         # Make sure to pull the hostname from config file.
                         print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "You've requested a password reset at the GRASA Event Locator. Please visit this linnk: http://grasa.larrimore.de/resetPWForm/" + resetlink))
-        context = {'email_sent': True}
-        return render(request, 'resetPW.html', context)
+
+        return render(request, 'resetPW.html')
 
 def resetPWForm(request, reset_string):
         if request.method == 'POST' and request.POST['new'] == request.POST['confirm']:
@@ -410,8 +409,7 @@ def approveUser(request, userID):
                 u = userInfo.objects.get(pk=userID)
                 u.isPending = False
                 u.save()
-                print(send_email([str(u.user)], "GRASA - Account Approved", "Your account for " + u.org_name + " at the GRASA Event Locator has been approved! Please login at http://grasa.larrimore.de/login.php to add events."))
-                print(send_email([u.contact_email], "GRASA - Alternate Contact", "You are the alternative contact for " + u.org_name + " at the GRASA Event Locator. Please contact them for further details."))
+                print(send_email([u.contact_email], "GRASA - Alternate Contact", "You are the alternative contact for " + u.org_name + " in the GRASA Event Locator. Please contact them for further details."))
                 return redirect("admin_page")
         else:
                 return redirect("login_page")

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -376,6 +376,7 @@ def resetpw(request):
         i = 0
         if request.method == 'POST':
                 if User.objects.filter(username=request.POST['emailAddr']).exists():
+                        context = {'email_sent': True}
                         with connection.cursor() as cursor:
                                 cursor.execute("DELETE FROM `grasa_event_locator_resetpwurls` WHERE `user_ID` = '" + request.POST['emailAddr'] + "';")
                         resetlink = ''.join([random.choice(string.ascii_letters + string.digits) for n in range(15)])
@@ -383,8 +384,8 @@ def resetpw(request):
                         resetPWURL.save()
                         # Make sure to pull the hostname from config file.
                         print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "You've requested a password reset at the GRASA Event Locator. Please visit this linnk: http://grasa.larrimore.de/resetPWForm/" + resetlink))
-
-        return render(request, 'resetPW.html')
+        context = {'email_sent': True}
+        return render(request, 'resetPW.html', context)
 
 def resetPWForm(request, reset_string):
         if request.method == 'POST' and request.POST['new'] == request.POST['confirm']:
@@ -409,7 +410,8 @@ def approveUser(request, userID):
                 u = userInfo.objects.get(pk=userID)
                 u.isPending = False
                 u.save()
-                print(send_email([u.contact_email], "GRASA - Alternate Contact", "You are the alternative contact for " + u.org_name + " in the GRASA Event Locator. Please contact them for further details."))
+                print(send_email([str(u.user)], "GRASA - Account Approved", "Your account for " + u.org_name + " at the GRASA Event Locator has been approved! Please login at http://grasa.larrimore.de/login.php to add events."))
+                print(send_email([u.contact_email], "GRASA - Alternate Contact", "You are the alternative contact for " + u.org_name + " at the GRASA Event Locator. Please contact them for further details."))
                 return redirect("admin_page")
         else:
                 return redirect("login_page")

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -376,7 +376,6 @@ def resetpw(request):
         i = 0
         if request.method == 'POST':
                 if User.objects.filter(username=request.POST['emailAddr']).exists():
-                        context = {'email_sent': True}
                         with connection.cursor() as cursor:
                                 cursor.execute("DELETE FROM `grasa_event_locator_resetpwurls` WHERE `user_ID` = '" + request.POST['emailAddr'] + "';")
                         resetlink = ''.join([random.choice(string.ascii_letters + string.digits) for n in range(15)])
@@ -384,8 +383,10 @@ def resetpw(request):
                         resetPWURL.save()
                         # Make sure to pull the hostname from config file.
                         print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "You've requested a password reset at the GRASA Event Locator. Please visit this linnk: http://grasa.larrimore.de/resetPWForm/" + resetlink))
-        context = {'email_sent': True}
-        return render(request, 'resetPW.html', context)
+                context = {'email_submitted': True}
+                return render(request, 'resetPW.html', context)
+        else:
+            return render(request, 'resetPW.html')
 
 def resetPWForm(request, reset_string):
         if request.method == 'POST' and request.POST['new'] == request.POST['confirm']:


### PR DESCRIPTION
This PR implements two features:

- When an email address is inputted into resetPW, no matter what was submitted in there, a message will pop up indicating that if the email is associated with a provider account, an email will be sent.

- When a user is approved, the email address as well as the alt. contact will get emails. Going to stall on the rejection email until we figure out what we're doing about rejection messages.