### PR TITLE
Add GitHub Action for Black code formatter

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -1,0 +1,14 @@
+name: code quality
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  black_lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Reformat Python code with Black code formatter. https://github.com/psf/black
+      uses: lgeiger/black-action@master

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -12,3 +12,4 @@ jobs:
     - uses: actions/checkout@v1
     - name: Reformat Python code with Black code formatter. https://github.com/psf/black
       uses: lgeiger/black-action@master
+      args: "."


### PR DESCRIPTION
This commit adds a new GitHub Action for reformatting Python code according to the requirements / specs of PEP-8 / Black. This is part of #123 and unblocks #164.

The expected outcome of this commit is that new pull requests should automatically have their changes reformatted by Black once they are opened. This ensures that everyone on the team writes code in the same style.

This is not yet tested.