### PR TITLE
about page: Add high-level project description (closes #76)

### DIFF
--- a/grasa_event_locator/templates/about.html
+++ b/grasa_event_locator/templates/about.html
@@ -5,16 +5,23 @@
 		<div class="about-row">
             <br>
 			<h2 id="about">About Us</h2>
-			<span class="subhead">OUR STORY</span>
+			<span class="subhead">EVENT LOCATOR</span>
 
 			<p class="main-content">
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam sed nunc ac neque interdum euismod id sit amet purus. Nam ut dapibus purus, non laoreet lectus. Mauris et sollicitudin velit, malesuada aliquam neque. Mauris a vehicula erat, sit amet rhoncus ante. Praesent nulla mi, tincidunt et porttitor ac, congue in tellus. Aliquam erat volutpat. Nulla pretium non dolor sit amet euismod. Donec a metus id elit cursus fermentum a sed lectus. Integer iaculis blandit mauris, quis pharetra ex varius sit amet. Morbi suscipit magna lectus, et interdum tellus porttitor a. Pellentesque volutpat luctus consequat. Phasellus nisi lorem, sodales ac malesuada at, molestie non metus. Sed finibus tincidunt elit ac bibendum. Donec non diam efficitur, pulvinar arcu iaculis, congue tortor. Curabitur enim metus, condimentum pellentesque iaculis ac, auctor eu odio.</p>
+            The GRASA Event Locator is an event locator system to connect Monroe County families to out-of-school programs in the Greater Rochester area. This application was created for the <a href="https://www.racf.org/About/Giving-Circles-Initiatives-and-Partnerships/Greater-Rochester-After-School-Alliance" target="_blank">Greater Rochester After-School Alliance</a> and Monroe County, New York by <a href="https://django-rit-grasa.readthedocs.io/en/latest/about/about-project/#project-team" target="_blank">Team Platypus</a> at the <a href="https://www.rit.edu/" target="_blank">Rochester Institute of Technology</a>.
+            </p>
 
-            <p>Phasellus volutpat lacus sit amet mi aliquam ultrices. Sed dui nisl, fermentum sit amet commodo ut, auctor et arcu. Proin non erat ut justo euismod viverra. Nunc tempus rhoncus tellus ac efficitur. Sed vel tincidunt eros, non venenatis nunc. Maecenas blandit erat varius leo dictum, a sagittis diam viverra. Integer et libero nec est placerat tincidunt. Pellentesque egestas, justo vitae molestie tincidunt, risus ipsum blandit erat, ac egestas lacus urna sed ligula. Proin id accumsan lorem, vel blandit justo. Aenean pellentesque at lorem non tincidunt. Aliquam efficitur vitae mi at rhoncus. Proin rutrum facilisis mi, a facilisis nunc commodo vel. Ut pulvinar in diam non consectetur. Proin et tincidunt eros.
-
-
+            <p>
+            This takes the form of a web page containing a map that can be searched for after-school events. Users are presented with further information and registration options. This information was originally delivered via the <a href="http://exploremonroeny.com/calendar" target="_blank">Explore Monroe website</a> as well as a physical book, the “<a href="https://www2.monroecounty.gov/files/youth/Adult_Guide%202011.pdf" target="_blank">Adult Guide to Youth Services</a>”, both which GRASA and the Monroe County government wish to retire due to lack of maintenance. GRASA representatives presented Team Platypus with several examples, including <a href="http://youthprogramlocator.newark-thrives.org/" target="_blank">Newark Thrives</a> and the <a href="http://dasn.force.com/dapf/ProgramFinder" target="_blank">Dallas After-School Network</a> as examples of final deliverables.
 			</p>
 
+            <p>
+            The main highlight of the GRASA Event Locator is the map. Similar to the <a href="http://youthprogramlocator.newark-thrives.org/" target="_blank">Newark Thrives Youth Program Locator</a>, the end user uses a search box with various filters and an interactive map to locate programs. Evemts are added to the site by providers via an account system. An administrator from GRASA and the Monroe County government approves these accounts, as well as creation and edits of an event.
+            </p>
+
+            <p>
+            For the purposes of this project, the Event Locator does not support programs and events beyond Monroe County.
+            </p>
 		</div>
 
 	</div>


### PR DESCRIPTION
This commit adds the high-level project description, as written in our
existing documentation, to the "About us" page on the front-end. It's
hard-coded for now, but this is something we could look at moving to a
config file if we have time.

Closes #76.