### PR TITLE
Reset PW Expiration

### DIFF
--- a/grasa_event_locator/models.py
+++ b/grasa_event_locator/models.py
@@ -141,3 +141,4 @@ class Program(models.Model):
 class resetPWURLs(models.Model):
     user_ID = models.TextField(default="DEFAULT PROVIDER")
     reset_string = models.CharField(max_length=15, default="A DEFAULTSTRING")
+    expiry_time =  models.CharField(max_length=26, default="NO TIMESTAMP")

--- a/grasa_event_locator/templates/resetPWForm.html
+++ b/grasa_event_locator/templates/resetPWForm.html
@@ -1,9 +1,19 @@
 {% include "header.html" %}
 
-
   <div class="form-changePW">
+	    {% if expired %}
+	     <div class="alert alert-warning" role="alert">
+          This password reset link has expired, please generate a new one <a href="/resetPW.html">here.</a>
+        </div>
+	  	{% endif %}
+        {% if pwdmatch %}
+        <div class="alert alert-warning" role="alert">
+          Please confirm that the inputted passwords match.
+        </div>
+        {% endif %}
 	<form method="post">
 	{% csrf_token %}
+		{% if valid_string %}
 		<label for="currentPW">New Password</label>
 		<input type="password" id="currentPW" class="form-control" name="new" required autofocus>
 		</br>
@@ -19,7 +29,7 @@
             <button type="submit" class="btn btn-lg btn-primary btn-block">Submit</button>
         </div>
 	</div>
-
+		{% endif %}
 	</form>
   </div>
 

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -481,7 +481,7 @@ def resetpw(request):
                         resetPWURL = resetPWURLs(user_ID = request.POST['emailAddr'], reset_string= resetlink, expiry_time= (datetime.now() + timedelta(minutes = 60)))
                         resetPWURL.save()
                         # Make sure to pull the hostname from config file.
-                        print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "You've requested a password reset at the GRASA Event Locator. Please visit this link: http://grasa.larrimore.de/resetPWForm/" + resetlink + ". This link expires in 10 minutes."))
+                        print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "You've requested a password reset at the GRASA Event Locator. Please visit this link: http://grasa.larrimore.de/resetPWForm/" + resetlink + ". This link expires in an hour."))
                 context = {'email_submitted': True}
                 return render(request, 'resetPW.html', context)
         else:
@@ -489,7 +489,7 @@ def resetpw(request):
 
 def resetPWForm(request, reset_string):
         try:
-            #Check if the current time is greater than the timestamp in the table (which is 10 minutes after submission)
+            #Check if the current time is greater than the timestamp in the table (which is 60 minutes after submission)
             if datetime.now() > datetime.strptime(resetPWURLs.objects.get(reset_string=reset_string).expiry_time, '%Y-%m-%d %H:%M:%S.%f'):
                 #If so, show the expired message, hide the form.
                 context = {'expired': True, "valid_string" : False}

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -481,7 +481,7 @@ def resetpw(request):
                 if User.objects.filter(username=request.POST['emailAddr']).exists():
                         resetPWURLs.objects.get(user_ID = request.POST['emailAddr']).delete()
                         resetlink = ''.join([random.choice(string.ascii_letters + string.digits) for n in range(15)])
-                        resetPWURL = resetPWURLs(user_ID = request.POST['emailAddr'], reset_string= resetlink, expiry_time= (datetime.now() + timedelta(minutes = 10)))
+                        resetPWURL = resetPWURLs(user_ID = request.POST['emailAddr'], reset_string= resetlink, expiry_time= (datetime.now() + timedelta(minutes = 60)))
                         resetPWURL.save()
                         # Make sure to pull the hostname from config file.
                         print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "You've requested a password reset at the GRASA Event Locator. Please visit this link: http://grasa.larrimore.de/resetPWForm/" + resetlink + ". This link expires in 10 minutes."))

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -478,7 +478,7 @@ def resetpw(request):
                         with connection.cursor() as cursor:
                                 cursor.execute("DELETE FROM `grasa_event_locator_resetpwurls` WHERE `user_ID` = '" + request.POST['emailAddr'] + "';")
                         resetlink = ''.join([random.choice(string.ascii_letters + string.digits) for n in range(15)])
-                        resetPWURL = resetPWURLs(user_ID = request.POST['emailAddr'], reset_string= resetlink, expiry_time= (datetime.now() + timedelta(minutes = 10)))
+                        resetPWURL = resetPWURLs(user_ID = request.POST['emailAddr'], reset_string= resetlink, expiry_time= (datetime.now() + timedelta(minutes = 60)))
                         resetPWURL.save()
                         # Make sure to pull the hostname from config file.
                         print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "You've requested a password reset at the GRASA Event Locator. Please visit this link: http://grasa.larrimore.de/resetPWForm/" + resetlink + ". This link expires in 10 minutes."))

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -484,7 +484,7 @@ def resetpw(request):
                         resetPWURL = resetPWURLs(user_ID = request.POST['emailAddr'], reset_string= resetlink, expiry_time= (datetime.now() + timedelta(minutes = 60)))
                         resetPWURL.save()
                         # Make sure to pull the hostname from config file.
-                        print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "You've requested a password reset at the GRASA Event Locator. Please visit this link: http://grasa.larrimore.de/resetPWForm/" + resetlink + ". This link expires in 10 minutes."))
+                        print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "You've requested a password reset at the GRASA Event Locator. Please visit this link: http://grasa.larrimore.de/resetPWForm/" + resetlink + ". This link expires in an hour."))
                 context = {'email_submitted': True}
                 return render(request, 'resetPW.html', context)
         else:
@@ -492,7 +492,7 @@ def resetpw(request):
 
 def resetPWForm(request, reset_string):
         try:
-            #Check if the current time is greater than the timestamp in the table (which is 10 minutes after submission)
+            #Check if the current time is greater than the timestamp in the table (which is 60 minutes after submission)
             if datetime.now() > datetime.strptime(resetPWURLs.objects.get(reset_string=reset_string).expiry_time, '%Y-%m-%d %H:%M:%S.%f'):
                 #If so, show the expired message, hide the form.
                 context = {'expired': True, "valid_string" : False}

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -12,13 +12,11 @@ from django.shortcuts import redirect
 from django.db import connection
 from haystack.generic_views import SearchView
 from haystack.forms import SearchForm
-import time
 from django.db import *
 import rebuildIndex
 import random
 import string
-import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from django.shortcuts import reverse
 from smtplib import *
 
@@ -480,29 +478,56 @@ def resetpw(request):
                         with connection.cursor() as cursor:
                                 cursor.execute("DELETE FROM `grasa_event_locator_resetpwurls` WHERE `user_ID` = '" + request.POST['emailAddr'] + "';")
                         resetlink = ''.join([random.choice(string.ascii_letters + string.digits) for n in range(15)])
-                        resetPWURL = resetPWURLs(user_ID = request.POST['emailAddr'], reset_string= resetlink)
+                        resetPWURL = resetPWURLs(user_ID = request.POST['emailAddr'], reset_string= resetlink, expiry_time= (datetime.now() + timedelta(minutes = 10)))
                         resetPWURL.save()
                         # Make sure to pull the hostname from config file.
-                        print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "You've requested a password reset at the GRASA Event Locator. Please visit this linnk: http://grasa.larrimore.de/resetPWForm/" + resetlink))
+                        print(send_email([request.POST['emailAddr']], "GRASA - Reset Password", "You've requested a password reset at the GRASA Event Locator. Please visit this link: http://grasa.larrimore.de/resetPWForm/" + resetlink + ". This link expires in 10 minutes."))
                 context = {'email_submitted': True}
                 return render(request, 'resetPW.html', context)
         else:
             return render(request, 'resetPW.html')
 
 def resetPWForm(request, reset_string):
-        if request.method == 'POST' and request.POST['new'] == request.POST['confirm']:
-                print(reset_string)
-                username = resetPWURLs.objects.get(reset_string=reset_string)
-                print(username)
-                user = User.objects.get(username=username.user_ID)
-                print(user)
-                user.set_password(request.POST['new'])
-                user.save()
+        try:
+            #Check if the current time is greater than the timestamp in the table (which is 10 minutes after submission)
+            if datetime.now() > datetime.strptime(resetPWURLs.objects.get(reset_string=reset_string).expiry_time, '%Y-%m-%d %H:%M:%S.%f'):
+                #If so, show the expired message, hide the form.
+                context = {'expired': True, "valid_string" : False}
+                # Then delete the associated table entry that's out of date.
                 with connection.cursor() as cursor:
-                        cursor.execute(
-                                "DELETE FROM `grasa_event_locator_resetpwurls` WHERE `user_ID` = '" + username.user_ID + "';")
-                return redirect("login_page")
+                    cursor.execute(
+                        "DELETE FROM `grasa_event_locator_resetpwurls` WHERE `user_ID` = '" + resetPWURLs.objects.get(
+                            reset_string=reset_string).user_ID + "';")
+                return render(request, 'resetPWForm.html', context)
+            # This is the most typical situation, where the form has a reset_string with a valid time.
+            else:
+                # The form should be showing if valid
+                context = {"valid_string" : True}
+                # If a post went through (check for the time again!), and the input was valid, change the password.
+                if request.method == 'POST':
+                    if request.POST['new'] == request.POST['confirm']:
+                        print(reset_string)
+                        username = resetPWURLs.objects.get(reset_string=reset_string)
+                        user = User.objects.get(username=username.user_ID)
+                        user.set_password(request.POST['new'])
+                        user.save()
+                        # And remove the associated table entry.
+                        with connection.cursor() as cursor:
+                            cursor.execute(
+                                "DELETE FROM `grasa_event_locator_resetpwurls` WHERE `user_ID` = '" + resetPWURLs.objects.get(
+                                    reset_string=reset_string).user_ID + "';")
+                        return redirect("login_page")
+                    else:
+                        # If the inputted passwords do not match, bring up the "confirm match" message, and continue to show the form.
+                        context = {'pwdmatch' : True, 'valid_string' : True}
+                        return render(request, 'resetPWForm.html', context)
+                return render(request, 'resetPWForm.html', context)
+        except resetPWURLs.DoesNotExist:
+            # If the entry is not found, hide the resetPW form and show the "link expired message".
+            context = {'expired': True, "valid_string" : False}
+            return render(request, 'resetPWForm.html', context)
         else:
+                #This is only triggered when no reset string is present. Note that this situation cannot happen without editing the URL file.
                 return render(request, 'resetPWForm.html')
 
 #Functional views, post only, need to be logged in admin, self defining names


### PR DESCRIPTION
This commit makes several changes to the Reset Password Functionality. Originally, a reset_string would stay in the table until it's associated account's password was reset. This has been altered.

Instead, a timestamp for 10 minutes past the strings' creation is now a part of the table entry. If a user visits the reset password form URL after that timestamp, the site will instead show a "Link Expired" message, the actual form will not appear, and the table entry will remove itself. This will also occur if the reset string is not in the table (maybe due to trying to use the URL twice).

If a password was set correctly, then the table entry will continue to delete itself like before so the URL cannot be reused (though now the form won't show if someone tries :D)

In addition, another message is now in place if the inputted passwords (new and confirm) do not match.

Models: Add field for the expiration time.
resetPWForm: Add messages for if the link expired, and if the passwords do not match.
Views: Add amount of time till link expiration in the resetPW email, added code and comments for code that handles the resetPW process and the reset_string.