### PR TITLE
config: Load organization contact info from config (closes #157)

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -12,6 +12,28 @@
 
 admin_email: "admin@example.com"
 
+#                      ##### organization_contact #####
+# Change the contact information for the organization in the footer of the
+# website. This information should always remain accurate and correct.
+
+organization_contact:
+  address:
+    street_num: "500"
+    street_name: "East Ave"
+    city: "Rochester"
+    state: "NY"
+    zip: "14607"
+  hours:
+    weekdays: "9am – 5pm"
+    weekends: "closed"
+  phone_num: "(585) 271-4100"
+  email: "racf@racf.org"
+  social_media:
+    facebook: "https://www.facebook.com/GreaterRochesterAfterSchoolAlliance/"
+    twitter: "https://twitter.com/GRASArochester"
+    linkedin: "https://www.linkedin.com/company/rochester-area-community-foundation/"
+  website: "https://www.monroecounty.gov"
+
 #                            ##### database #####
 # Edit database connectivity settings. Default config in example uses the
 # docker-compose defaults for local development. For local development, keep

--- a/grasa_event_locator/forms.py
+++ b/grasa_event_locator/forms.py
@@ -1,9 +1,8 @@
-from django import forms
 from .forms import *
-from haystack.forms import SearchForm
-
+from django import forms
 from haystack import connections
 from haystack.constants import DEFAULT_ALIAS
+from haystack.forms import SearchForm
 from haystack.query import EmptySearchQuerySet, SearchQuerySet
 from haystack.utils import get_model_ct
 from haystack.utils.app_loading import haystack_get_model

--- a/grasa_event_locator/helpers.py
+++ b/grasa_event_locator/helpers.py
@@ -1,3 +1,10 @@
+"""Miscellaneous helper functions used across grasa_event_locator.
+
+This file includes various functions used across different parts of the Django
+application. Additional code should only be added to this file if there is not a more
+suitable place somewhere else.
+"""
+
 from django.core.mail import send_mail
 from django.db import connection
 from django.template.loader import render_to_string
@@ -25,7 +32,7 @@ def change_username(old_email, new_email, request):
             "new_email": new_email,
         })
     )
-    return 0
+    return
 
 
 def write_categories_table():

--- a/grasa_event_locator/models.py
+++ b/grasa_event_locator/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import User
 
+
 # Users in our DataBase
 class userInfo(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)

--- a/grasa_event_locator/templates/about.html
+++ b/grasa_event_locator/templates/about.html
@@ -1,19 +1,19 @@
 {% include "header.html" %}
 
-	<div class="container about-container">
+    <div class="container about-container">
 
-		<div class="about-row">
+        <div class="about-row">
             <br>
-			<h2 id="about">About Us</h2>
-			<span class="subhead">EVENT LOCATOR</span>
+            <h2 id="about">About Us</h2>
+            <span class="subhead">EVENT LOCATOR</span>
 
-			<p class="main-content">
+            <p class="main-content">
             The GRASA Event Locator is an event locator system to connect Monroe County families to out-of-school programs in the Greater Rochester area. This application was created for the <a href="https://www.racf.org/About/Giving-Circles-Initiatives-and-Partnerships/Greater-Rochester-After-School-Alliance" target="_blank">Greater Rochester After-School Alliance</a> and Monroe County, New York by <a href="https://django-rit-grasa.readthedocs.io/en/latest/about/about-project/#project-team" target="_blank">Team Platypus</a> at the <a href="https://www.rit.edu/" target="_blank">Rochester Institute of Technology</a>.
             </p>
 
             <p>
             This takes the form of a web page containing a map that can be searched for after-school events. Users are presented with further information and registration options. This information was originally delivered via the <a href="http://exploremonroeny.com/calendar" target="_blank">Explore Monroe website</a> as well as a physical book, the “<a href="https://www2.monroecounty.gov/files/youth/Adult_Guide%202011.pdf" target="_blank">Adult Guide to Youth Services</a>”, both which GRASA and the Monroe County government wish to retire due to lack of maintenance. GRASA representatives presented Team Platypus with several examples, including <a href="http://youthprogramlocator.newark-thrives.org/" target="_blank">Newark Thrives</a> and the <a href="http://dasn.force.com/dapf/ProgramFinder" target="_blank">Dallas After-School Network</a> as examples of final deliverables.
-			</p>
+            </p>
 
             <p>
             The main highlight of the GRASA Event Locator is the map. Similar to the <a href="http://youthprogramlocator.newark-thrives.org/" target="_blank">Newark Thrives Youth Program Locator</a>, the end user uses a search box with various filters and an interactive map to locate programs. Evemts are added to the site by providers via an account system. An administrator from GRASA and the Monroe County government approves these accounts, as well as creation and edits of an event.
@@ -22,76 +22,60 @@
             <p>
             For the purposes of this project, the Event Locator does not support programs and events beyond Monroe County.
             </p>
-		</div>
+        </div>
 
-	</div>
-	<div class="container contact-container">
+    </div>
+    <div class="container contact-container">
 
-				<h2 id="contact">Contact Us</h2>
-				<hr><br>
-				<div class="row">
+                <h2 id="contact">Contact Us</h2>
+                <hr><br>
+                <div class="row">
 
-					<div class="col-lg-3 address">
+                    <div class="col-lg-3 address">
+                        <h5>Office Hours</h5>
+                        <p>
+                            Mon - Fri : {{ config.organization_contact.hours.weekdays }} <br>
+                            Sat - Sun : {{ config.organization_contact.hours.weekends }}
+                        </p>
+                        <br>
+                        <h5>Website</h5>
+                            <a href="{{ config.organization_contact.website }}" target="_blank"><i class="fa fa-globe"></i>
+                            {{ config.organization_contact.website }}</a>
+                    </div>
 
-						<h5>Office Hours</h5>
-						<p>
-							Mon - Fri : 9am - 5pm <br>
-							Sat - Sun : closed
-						</p>
-						<br>
-						<h5>Website</h5>
-							<a href="https://www.monroecounty.gov/" target="_blank"><i class="fa fa-globe"></i>
-							www.moroecounty.gov </a>
+                    <div class="col-lg-3 address">
 
-					</div>
+                        <h5>Address</h5>
+                        <p>
+                            {{ config.organization_contact.address.street_num }} {{ config.organization_contact.address.street_name }} <br>
+                            {{ config.organization_contact.address.city }}, {{ config.organization_contact.address.state }} {{ config.organization_contact.address.zip }}
+                        </p>
+                    </div>
 
-					<div class="col-lg-3 address">
+                    <div class="col-lg-3 address">
 
-						<h5>Address</h5>
-						<p>
-							111 Monroe County <br>
-							New York 14623
+                        <h5 id="office">Call Us </h5>
+                        <a href="tel:+5951234567"><i class="fa fa-phone" aria-hidden="true"></i>
+                        (+1) {{ config.organization_contact.phone_num }} </a><br>
 
-						</p>
-					</div>
+                    </div>
 
-					<div class="col-lg-3 address">
+                    <div class="col-lg-3 address">
 
-						<h5 id="office">Call Us </h5>
+                        <h5 id="email">Email</h5>
+                        <a href="mailto:{{ config.admin_email }}"><i class="fa fa-envelope"></i>
+                        {{ config.admin_email }}</a>
 
-						<h6> HR Office: </h6>
-							<a href="tel:+5951234567"><i class="fa fa-phone" aria-hidden="true"></i> (+1) 585-123-4567 </a><br>
+                    </div>
+                </div>
+            </div>
 
-
-						<h6>IT Office: </h6>
-							<a href="tel:+5951234567"><i class="fa fa-phone" aria-hidden="true"></i> (+1) 585-123-4567 </a><br>
-
-					</div>
-
-					<div class="col-lg-3 address">
-
-						<h5 id="email">Email</h5>
-
-						<h6> HR Office: </h6>
-							<a href="mailto:johndoe@gmail.com"><i class="fa fa-envelope"></i>
-							johndoe@gmail.com</a>
-
-
-						<h6> IT Office: </h6>
-							<a href="mailto:johndoe2@gmail.com"><i class="fa fa-envelope"></i>
-							johndoe@gmail.com</a>
-
-
-					</div>
-				</div>
-			</div>
-
-	<div class="container social-container">
-		<div>
-			<a href="#" class="fa fa-facebook"></a>
-			<a href="#" class="fa fa-twitter"></a>
-			<a href="#" class="fa fa-linkedin"></a>
-		</div>
-	</div>
+    <div class="container social-container">
+        <div>
+            <a href="{{ config.organization_contact.social_media.facebook }}" class="fa fa-facebook"></a>
+            <a href="{{ config.organization_contact.social_media.twitter }}" class="fa fa-twitter"></a>
+            <a href="{{ config.organization_contact.social_media.linkedin }}" class="fa fa-linkedin"></a>
+        </div>
+    </div>
 
 {% include "footer.html" %}

--- a/grasa_event_locator/urls.py
+++ b/grasa_event_locator/urls.py
@@ -1,9 +1,7 @@
-from django.conf import settings
-from django.conf.urls import include, url
-from django.conf.urls.static import static
 from . import views
-from django.urls import path
+from django.conf.urls import url
 from django.contrib import admin
+from django.urls import path
 
 urlpatterns = [
     path('about.html', views.aboutContact, name='about_contact'),

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -3,18 +3,14 @@ import random
 import string
 
 from .forms import *
-from .functions import *
-from .models import *
+from .helpers import change_username, send_email, write_categories_table
+from .models import userInfo, Category, Program, resetPWURLs
 from datetime import datetime, timedelta
 from django.conf import settings
 from django.contrib.auth import authenticate, login as auth_login
 from django.contrib.auth.decorators import permission_required
-from django.contrib.auth import logout
 from django.contrib.auth.models import User as UserAccount
-from django.contrib.admin.views.decorators import staff_member_required
-from django.shortcuts import redirect
 from django.db import connection
-from django.db import *
 from django.http import HttpResponseRedirect
 from django.shortcuts import render, reverse
 from django.template.loader import render_to_string
@@ -24,7 +20,9 @@ from smtplib import SMTPRecipientsRefused
 
 
 def aboutContact(request):
-    return render(request, 'about.html')
+    return render(request, 'about.html', context={
+        "config": settings.CONFIG,
+    })
 
 
 def admin(request):
@@ -66,7 +64,7 @@ def admin(request):
                             denyEvent(request, request.POST.get('eventid'), request.POST.get('reason'))
                         return render(request, 'admin.html', context)
                 return render(request, 'admin.html', context)
-        if request.user.is_authenticated and request.user.userinfo.isAdmin == False:
+        if request.user.is_authenticated and request.user.userinfo.isAdmin is False:
                 return HttpResponseRedirect(reverse('provider_page'))
         else:
                 return HttpResponseRedirect(reverse('login_page'))


### PR DESCRIPTION
This commit does a few things, but its primary goal is to load info
about an organization (e.g. business hours, address, social media, etc.)
from the standard config file. This is done with changes to `views.py`,
`about.html`, and `config.yml.example`.

This branch was old and I was also working on other changes that got
mashed up with this commit. Some of them are reordering package import
statements according to PEP-8, others are whitespace changes… I know it
doesn't make it the easiest commit to review, I'll work to avoid this in
the future.

I successfully tested this changes on my own, but extra validation is
welcome.

**NOTE**: This requires changes to the `config.yml` file we use. For
local development, I suggest copying `config.yml.example` and
overwriting the `config.yml`, as the example file is written to work
out-of-the-box with local development.

Closes #157. There are no more planned additions to the config file
beyond this point. Initial admin account will be carried out in #162.