### PR TITLE
Deny popups

### DIFF
--- a/grasa_event_locator/templates/admin.html
+++ b/grasa_event_locator/templates/admin.html
@@ -84,7 +84,7 @@
                       </td>
                       <td>Pending</td>
                       <td><a href="{% url 'approve_user' pendingUser.id %}"><button type="button" class="btn btn-outline-success">Approve</button></a></td>
-                      <td><a href="{% url 'deny_user' pendingUser.id %}"><button type="button" class="btn btn-outline-danger">Deny</button></a></td>
+                      <td><button type="button" class="btn btn-outline-danger" data-toggle="modal" data-target="#denyUserModal{{pendingUser.id}}">Deny</button></td>
                     </tr>
 
                     <!--Deny User Modal-->
@@ -215,7 +215,7 @@
                       <td>Pending</td>
                       <td><a href="{% url 'event_page' pendingEdit.id %}"><button type="button" class="btn btn-outline-info view-event">View</button></a></td>
                       <td><a href="{% url 'approve_edit' pendingEdit.id %}"><button type="button" class="btn btn-outline-success">Approve</button></a></td>
-                      <td><a href="{% url 'deny_edit' pendingEdit.id %}"><button type="button" class="btn btn-outline-danger">Deny</button></a></td>
+                      <td><button type="button" class="btn btn-outline-danger" data-toggle="modal" data-target="#denyeditEventModal{{pendingEdit.id}}">Deny</button></td>
                     </tr>
 
                     <!--Deny Edit Event Modal-->

--- a/grasa_event_locator/templates/admin.html
+++ b/grasa_event_locator/templates/admin.html
@@ -86,10 +86,48 @@
                       <td><a href="{% url 'approve_user' pendingUser.id %}"><button type="button" class="btn btn-outline-success">Approve</button></a></td>
                       <td><a href="{% url 'deny_user' pendingUser.id %}"><button type="button" class="btn btn-outline-danger">Deny</button></a></td>
                     </tr>
+
+                    <!--Deny User Modal-->
+                    <div class="modal fade" id="denyUserModal{{pendingUser.id}}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel2" aria-hidden="true">
+                      <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                          <div class="modal-header">
+                            <h5 class="modal-title" id="exampleModalLabel2">Deny  New Provider</h5>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                              <span aria-hidden="true">&times;</span>
+                            </button>
+                          </div>
+                              <form class="" novalidate method="POST" action="admin.html">{% csrf_token %}
+
+                              <div class="modal-body">
+
+                                <div class="row">
+                                    <div class="col-sm-12">
+
+                                        <div class="form-group col-md-12">
+                                            <label for="reason">Please explain your reason for denying <b>{{ pendingUser.org_name }}</b>:</label>
+                                            <textarea name="deny_user_reason" class="form-control" id="exampleFormControlTextarea1" rows="6" placeholder="" required></textarea>
+                                            <div class="invalid-feedback">
+                                                Please provide an explanation.
+                                            </div>
+                                            <input type="hidden" name="userid" value={{ pendingUser.id }} readonly>
+                                            <div class="text-muted form-text">This will be sent to {{ pendingUser.user }}.</div>
+                                        </div>
+                                    </div>
+                                </div>
+                              </div>
+                              <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                                <button type="submit" class="btn btn-danger" value="Submit">Deny Provider</button>
+                              </div>
+                            </form>
+                        </div>
+                      </div>
+                    </div>
                     {% endfor %}
                   </tbody>
                 </table>
-        <!--New Event Approval-->
+            <!--New Event Approval-->
             <div class="twentyblock"></div>
             <h4 class="top-20">New Events</h4>
                 <table class="table  table-bordered">
@@ -113,9 +151,8 @@
                       <td><a href="{% url 'approve_event' pendingEvent.id %}"><button type="button" class="btn btn-outline-success">Approve</button></a></td>
                       <td><button type="button" class="btn btn-outline-danger" data-toggle="modal" data-target="#denyEventModal">Deny</button></td>
                     </tr>
-                    
-                      
-                       <!--Deny New Event Modal-->
+
+                    <!--Deny New Event Modal-->
                     <div class="modal fade" id="denyEventModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel2" aria-hidden="true">
                       <div class="modal-dialog" role="document">
                         <div class="modal-content">
@@ -133,17 +170,16 @@
 
                                         <div class="form-group col-md-12">
                                             <label for="reason">Please explain your reason for denying <b>{{ pendingEvent.title }}</b>:</label>
-                                            <textarea name="reason" class="form-control" id="exampleFormControlTextarea1" rows="6" placeholder="" required></textarea>
+                                            <textarea name="deny_event_reason" class="form-control" id="exampleFormControlTextarea1" rows="6" placeholder="" required></textarea>
                                             <div class="invalid-feedback">
                                                 Please provide an explanation.
                                             </div>
                                             <input type="hidden" name="eventid" value={{ pendingEvent.id }} readonly>
                                             <div class="text-muted form-text">This will be sent to {{ pendingEvent.user_id.org_name }}.</div>
                                         </div>
-
-
                                     </div>
                                 </div>
+
                               </div>
 
                               <div class="modal-footer">
@@ -181,6 +217,47 @@
                       <td><a href="{% url 'approve_edit' pendingEdit.id %}"><button type="button" class="btn btn-outline-success">Approve</button></a></td>
                       <td><a href="{% url 'deny_edit' pendingEdit.id %}"><button type="button" class="btn btn-outline-danger">Deny</button></a></td>
                     </tr>
+
+                    <!--Deny Edit Event Modal-->
+                    <div class="modal fade" id="denyeditEventModal{{pendingEdit.id}}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel2" aria-hidden="true">
+                      <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                          <div class="modal-header">
+                            <h5 class="modal-title" id="exampleModalLabel2">Deny  Updated Event</h5>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                              <span aria-hidden="true">&times;</span>
+                            </button>
+                          </div>
+                              <form class="" novalidate method="POST" action="admin.html">{% csrf_token %}
+
+                                  <div class="modal-body">
+
+                                    <div class="row">
+                                        <div class="col-sm-12">
+
+                                            <div class="form-group col-md-12">
+                                                <label for="reason">Please explain your reason for denying the changes to <b>{{ pendingEdit.title }}</b>:</label>
+                                                <textarea name="edit_event_reason" class="form-control" id="exampleFormControlTextarea1" rows="6" placeholder="" required></textarea>
+                                                <div class="invalid-feedback">
+                                                    Please provide an explanation.
+                                                </div>
+                                                <input type="hidden" name="editeventid" value={{ pendingEdit.id }} readonly>
+                                                <div class="text-muted form-text">This will be sent to {{ pendingEdit.user_id.org_name }}.</div>
+                                            </div>
+
+
+                                        </div>
+                                    </div>
+                                  </div>
+
+                                  <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                                    <button type="submit" class="btn btn-danger" value="Submit">Deny Event</button>
+                                  </div>
+                              </form>
+                        </div>
+                      </div>
+                    </div>
                     {% endfor %}
                   </tbody>
                 </table>

--- a/grasa_event_locator/templates/messaging/edit_denied_confirm_mail.txt
+++ b/grasa_event_locator/templates/messaging/edit_denied_confirm_mail.txt
@@ -1,4 +1,7 @@
 Hello,
 
-The edit to your event, "{{ program.title }}", was rejected. Contact an admin
-({{ config.admin_email }}) for more details.
+The edit to your event, "{{ program.title }}", was rejected for the following reason:
+
+"{{ denied_reason }}"
+
+Contact an admin for additional details: {{ config.admin_email }}

--- a/grasa_event_locator/templates/messaging/provider_account_denied_mail.txt
+++ b/grasa_event_locator/templates/messaging/provider_account_denied_mail.txt
@@ -1,5 +1,7 @@
 Hello,
 
-Your account for {{ user.org_name }} at the GRASA Event Locator was rejected.
-There may have been an issue with your account registration. Please contact an
-admin ({{ config.admin_email }}) for more information.
+Your account for {{ user.org_name }} at the GRASA Event Locator was rejected for the following reason:
+
+"{{ denied_reason }}"
+
+Please contact an admin ({{ config.admin_email }}) for more information.


### PR DESCRIPTION
This completes the modal functionality for sending emails to the user for various rejections.

admin.html: Linked forms to the back end.
edit_denied_confirm_mail.txt: message altered to include the denied reason.
provider_account_denied_mail.txt: message altered to include the denied reason.
views.py: Re-imported some classes that were removed previously but are still used in views. Implemented code in the deny functions and the admin view to pass the reason to the context of the email.