### PR TITLE
docs: Update start-fresh page based on recent changes

### DIFF
--- a/docs/dev/start-fresh.md
+++ b/docs/dev/start-fresh.md
@@ -9,31 +9,26 @@ This page explains how to do a full reset and start with a fresh environment:
 
 ## Create a fresh environment
 
-- Copy the file `config.yml.example` and rename it `config.yml`.
-- Run `docker-compose up --build`.
-- The site is now viewable at [localhost:8000](http://localhost:8000), but wait!
-- In a separate shell window, run `docker ps`, which shows all running containers. They should be _mariadb_ and _django-rit-grasa_.
-    - If for some reason, they are not both there, use `docker ps -a` to get the name of the list of all containers, including the non running ones, then `docker start [containerID]` to start them.
-- Run the command `docker exec -it [containerID for the mariadb container] /bin/bash`
-- Run `mysql -u grasaadmin -p`.
-- Password is `djangoGrasa2019`.
-- In mySQL, `DROP DATABASE grasa_event_locator`, and `CREATE DATABASE grasa_event_locator`.
-- Type `exit;` to exit mySQL, and `exit` again to leave the mariadb container.
-- Run the command `docker exec -it [containerID for the django container] /bin/bash`.
-- Run `python3 manage.py makemigrations`
-- Run `python3 manage.py migrate`
-- Run `python3 manage.py rebuild_index`
-- Visit [localhost:8000](http://localhost:8000) in a browser
+1. Make sure the application is stopped (`docker-compose down`).
+2. Delete the database Docker volume (`docker volume rm django-rit-grasa_djangograsa_db`).
+3. Make a copy of`config.yml.example` and name it `config.yml`.
+4. Rebuild the project containers and start the app (`docker-compose up --build`).
+5. In a separate shell window, run `docker ps`, which shows all running containers. They should be _mariadb_ and _django-rit-grasa_.
+    * If for some reason, they are not both there, use `docker ps -a` to get the name of the list of all containers, including the non running ones, then `docker start [containerID]` to start them.
+6. Run the command `docker exec -it [containerID for the django container] /bin/bash`.
+7. Run `python3 manage.py migrate`
+8. Run `python3 manage.py rebuild_index`
+9. Visit [localhost:8000](http://localhost:8000) in a browser
 
 ## Initial app configuration
 
-The following three steps will need to be redone for deployment - as clearly clicking links will not be ideal.
+These directions only apply to local development.
+See the _Admin Quickstart_ for a production deployment.
 
-- Click the **Create Administrator Account** button in the header.
-- Click **Wipe Events & Recreate Categories** button in the header.
-- Site is now usable with the following admin account:
-    - Username: `grasatest@yahoo.com`
-    - Password: `Password1`
+1. Visit [localhost:8000/admin_user](http://localhost:8000/admin_user)
+2. Visit [localhost:8000/create_database](http://localhost:8000/create_database)
+3. Site is now usable with the following admin account:
+    * **Username**: `grasatest@yahoo.com`
+    * **Password**: `Password1`
 
-Note that for some reason, even if there is no migration file present in the migration folder, the `docker-compose` command still produces a `grasa_event_locator` database.
-Though right now, it is out of date, which warrants dropping it first before doing anything else.
+Note that the MySQL/MariaDB container is started automatically with a `grasa_event_locator` database, but this will not happen automatically in production.


### PR DESCRIPTION
A quick update to our start-fresh page about how to delete the database
now that it is stored as a volume. It also removes some steps that have
changed either by automation or change in workflow (e.g.
`makemigrations` is no longer necessary.

Related to #192.