### PR TITLE
activities: Expand STEM acronym fully

### DIFF
--- a/grasa_event_locator/forms.py
+++ b/grasa_event_locator/forms.py
@@ -23,7 +23,7 @@ activityList = [
     ("Public Speaking", "Public Speaking"),
     ("Social and Emotional Learning (SEL)", "Social and Emotional Learning (SEL)"),
     ("Sports and Recreation", "Sports and Recreation"),
-    ("STEM", "STEM"),
+    ("Science, Tech, Engineering, Math (STEM)", "Science, Tech, Engineering, Math (STEM)"),
     ("Tutoring", "Tutoring"),
     ("Other", "Other"),
 ]

--- a/grasa_event_locator/templates/header.html
+++ b/grasa_event_locator/templates/header.html
@@ -40,7 +40,7 @@
         var groupList = ["Activity", "Transportation", "Grades Served", "Gender","Distance", "Fees", "Timing"]
 
         //Activity
-        var activityList = ["Academic Support", "Arts and Culture", "Career or College Readiness", "Civic Engagement", "Community Service / Service Learning", "Entrepreneurship / Leadership", "Financial Literacy", "Health & Wellness", "Media Technology",  "Mentoring", "Nature & the Environment", "Play", "Public Speaking", "Social and Emotional Learning (SEL)", "Sports and Recreation", "STEM", "Tutoring", "Other"]
+        var activityList = ["Academic Support", "Arts and Culture", "Career or College Readiness", "Civic Engagement", "Community Service / Service Learning", "Entrepreneurship / Leadership", "Financial Literacy", "Health & Wellness", "Media Technology",  "Mentoring", "Nature & the Environment", "Play", "Public Speaking", "Social and Emotional Learning (SEL)", "Sports and Recreation", "Science, Tech, Engineering, Math (STEM)", "Tutoring", "Other"]
 
         //Transportation
         //Refactored to match header and forms as well as fix duplicate search bug


### PR DESCRIPTION
I changed this because I believe not every user will always understand
what S.T.E.M. stands for. I expanded it in this commit so it is always
explicitly stated.

This fixes a bug I introduced in #200 because I renamed the category in
the database during initialization (so in the back-end, this change
already exists). I discovered they were wrong when I tried to create an
event in the front-end with the STEM category and it broke.