### PR TITLE
config/site_name: Use hostname from config in emails

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -60,8 +60,10 @@ outgoing_smtp:
   password: "duhnsentqrxgadfh"
 
 #                           ##### site_name #####
-# Set the hostname of the website universally. The hostname set here will
-# reappear multiple times across the project. It is important for this to be an
-# existing DNS record.
+# Creates a resolveable hostname used across the website universally. The site
+# name set here reappears multiple times across the project. It is important
+# for this to be an existing DNS record.
 
-site_name: "localhost"
+site_name:
+  prefix: "http://"
+  fqdn: "localhost:8000"

--- a/config.yml.example
+++ b/config.yml.example
@@ -64,6 +64,11 @@ outgoing_smtp:
 # name set here reappears multiple times across the project. It is important
 # for this to be an existing DNS record.
 
-site_name:
-  prefix: "http://"
-  fqdn: "localhost:8000"
+site_name: "localhost:8000"
+
+# #### https #####
+# Whether external URLs (e.g. used in emails) write emails with "http://" or
+# "https://" prefixes. Set to yes for HTTPS, no for HTTP. Default is no.
+
+https: no
+

--- a/grasa_event_locator/templates/messaging/edit_approved_confirm_mail.txt
+++ b/grasa_event_locator/templates/messaging/edit_approved_confirm_mail.txt
@@ -2,4 +2,4 @@ Hello,
 
 The edit to your event, "{{ program.title }}", is approved! See it live below:
 
-{{ config.site_name.prefix }}{{ config.site_name.fqdn }}/event/{{ event_id }}
+http{% if config.https %}s{% endif %}://{{ config.site_name }}/event/{{ event_id }}

--- a/grasa_event_locator/templates/messaging/edit_approved_confirm_mail.txt
+++ b/grasa_event_locator/templates/messaging/edit_approved_confirm_mail.txt
@@ -2,4 +2,4 @@ Hello,
 
 The edit to your event, "{{ program.title }}", is approved! See it live below:
 
-http://grasa.larrimore.de/event/{{ event_id }}
+{{ config.site_name.prefix }}{{ config.site_name.fqdn }}/event/{{ event_id }}

--- a/grasa_event_locator/templates/messaging/event_approved_confirm_mail.txt
+++ b/grasa_event_locator/templates/messaging/event_approved_confirm_mail.txt
@@ -2,4 +2,4 @@ Hello,
 
 Your event, "{{ program.title }}", is approved! See it live below:
 
-{{ config.site_name.prefix }}{{ config.site_name.fqdn }}/event/{{ event_id }}
+http{% if config.https %}s{% endif %}://{{ config.site_name }}/event/{{ event_id }}

--- a/grasa_event_locator/templates/messaging/event_approved_confirm_mail.txt
+++ b/grasa_event_locator/templates/messaging/event_approved_confirm_mail.txt
@@ -2,4 +2,4 @@ Hello,
 
 Your event, "{{ program.title }}", is approved! See it live below:
 
-http://grasa.larrimore.de/event/{{ event_id }}
+{{ config.site_name.prefix }}{{ config.site_name.fqdn }}/event/{{ event_id }}

--- a/grasa_event_locator/templates/messaging/invite_provider_mail.txt
+++ b/grasa_event_locator/templates/messaging/invite_provider_mail.txt
@@ -5,7 +5,7 @@ the GRASA Event Locator!
 
 Finish setting up your account with this email here:
 
-http://grasa.larrimore.de/register.html
+{{ config.site_name.prefix }}{{ config.site_name.fqdn }}/register.html
 
 - Greater Rochester After-School Alliance (GRASA)
   Monroe County, NY

--- a/grasa_event_locator/templates/messaging/invite_provider_mail.txt
+++ b/grasa_event_locator/templates/messaging/invite_provider_mail.txt
@@ -5,7 +5,7 @@ the GRASA Event Locator!
 
 Finish setting up your account with this email here:
 
-{{ config.site_name.prefix }}{{ config.site_name.fqdn }}/register.html
+http{% if config.https %}s{% endif %}://{{ config.site_name }}/register.html
 
 - Greater Rochester After-School Alliance (GRASA)
   Monroe County, NY

--- a/grasa_event_locator/templates/messaging/provider_account_approval_mail.txt
+++ b/grasa_event_locator/templates/messaging/provider_account_approval_mail.txt
@@ -3,4 +3,4 @@ Hello,
 Your account for {{ user.org_name }} at the GRASA Event Locator is approved!
 Please login below to start adding events:
 
-{{ config.site_name.prefix }}{{ config.site_name.fqdn }}/login.html
+http{% if config.https %}s{% endif %}://{{ config.site_name }}/login.html

--- a/grasa_event_locator/templates/messaging/provider_account_approval_mail.txt
+++ b/grasa_event_locator/templates/messaging/provider_account_approval_mail.txt
@@ -3,4 +3,4 @@ Hello,
 Your account for {{ user.org_name }} at the GRASA Event Locator is approved!
 Please login below to start adding events:
 
-http://grasa.larrimore.de/login.html
+{{ config.site_name.prefix }}{{ config.site_name.fqdn }}/login.html

--- a/grasa_event_locator/templates/messaging/reset_password_mail.txt
+++ b/grasa_event_locator/templates/messaging/reset_password_mail.txt
@@ -2,7 +2,7 @@ Hello,
 
 You requested a password reset at the GRASA Event Locator. Reset it below:
 
-{{ config.site_name.prefix }}{{ config.site_name.fqdn }}/resetPWForm/{{ reset_link }}
+http{% if config.https %}s{% endif %}://{{ config.site_name }}/resetPWForm/{{ reset_link }}
 
 If you did not request this password reset, please disregard. Contact an admin
 with additional questions.

--- a/grasa_event_locator/templates/messaging/reset_password_mail.txt
+++ b/grasa_event_locator/templates/messaging/reset_password_mail.txt
@@ -2,7 +2,7 @@ Hello,
 
 You requested a password reset at the GRASA Event Locator. Reset it below:
 
-http://grasa.larrimore.de/resetPWForm/{{ reset_link }}
+{{ config.site_name.prefix }}{{ config.site_name.fqdn }}/resetPWForm/{{ reset_link }}
 
 If you did not request this password reset, please disregard. Contact an admin
 with additional questions.


### PR DESCRIPTION
This commit changes the site_name dict around in the config file. It
adds two fields: `prefix` and `fqdn`. These are in turn used in the
email template files to always use the configured URLs in places like
email.

There is probably a more elegant way to do this. But I am satisfied
enough with this because it puts the hostname in control of the user,
and so long as we are consistent about pulling the hostname in this way
across the back-end, it poses low risk.

Technically, this is lagging work on #157.