### PR TITLE
Additional config uses and refactoring

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -4,50 +4,14 @@
 # Note: The example config file ships a working config for local development
 # in Docker Compose only.
 
-# ##### secret_key #####
-# Specify a secret key to be used for encryption. This string should be
-# randomly generated and kept secure.
-# https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-SECRET_KEY
 
-secret_key: "TeamPlatypus2191"
-
-#                           ##### admin_email #####
-# Specify an email address for the first admin user. A user with admin
-# capabilities will be created with the specified email address and a default
-# password if and ONLY if no other admin users exist in the database. Make sure
-# to change the password from the default after logging in.
-
-admin_email: "admin@example.com"
-
-#                         ##### sysadmin_email #####
-# Specify an email address for logging notifications and error messages. This
-# address is intended for receipt of technical debugging information related to
-# the site. It is not recommended to set this to an individual person's email
-# inbox.
-
-sysadmin_email: "logging@example.com"
-
-#                      ##### organization_contact #####
-# Change the contact information for the organization in the footer of the
-# website. This information should always remain accurate and correct.
-
-organization_contact:
-  address:
-    street_num: "500"
-    street_name: "East Ave"
-    city: "Rochester"
-    state: "NY"
-    zip: "14607"
-  hours:
-    weekdays: "9am – 5pm"
-    weekends: "closed"
-  phone_num: "(585) 271-4100"
-  email: "racf@racf.org"
-  social_media:
-    facebook: "https://www.facebook.com/GreaterRochesterAfterSchoolAlliance/"
-    twitter: "https://twitter.com/GRASArochester"
-    linkedin: "https://www.linkedin.com/company/rochester-area-community-foundation/"
-  website: "https://www.monroecounty.gov"
+###############################################################################
+#                                                                             #
+#                                                                             #
+#                                  SECRETS                                    #
+#                                                                             #
+#                                                                             #
+###############################################################################
 
 #                            ##### database #####
 # Edit database connectivity settings. Default config in example uses the
@@ -74,16 +38,78 @@ outgoing_smtp:
   username: "grasatest@yahoo.com"
   password: "duhnsentqrxgadfh"
 
-#                           ##### site_name #####
-# Creates a resolveable hostname used across the website universally. The site
-# name set here reappears multiple times across the project. It is important
-# for this to be an existing DNS record.
+#                           ##### secret_key #####
+# Specify a secret key to be used for encryption. This string should be
+# randomly generated and kept secure.
+# https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-SECRET_KEY
 
-site_name: "localhost:8000"
+secret_key: "TeamPlatypus2191"
 
-# #### https #####
+
+###############################################################################
+#                                                                             #
+#                                                                             #
+#                                   EMAILS                                    #
+#                                                                             #
+#                                                                             #
+###############################################################################
+
+#                           ##### admin_email #####
+# Specify an email address for the first admin user. A user with admin
+# capabilities will be created with the specified email address and a default
+# password if and ONLY if no other admin users exist in the database. Make sure
+# to change the password from the default after logging in.
+
+admin_email: "admin@example.com"
+
+#                         ##### sysadmin_email #####
+# Specify an email address for logging notifications and error messages. This
+# address is intended for receipt of technical debugging information related to
+# the site. It is not recommended to set this to an individual person's email
+# inbox.
+
+sysadmin_email: "logging@example.com"
+
+
+###############################################################################
+#                                                                             #
+#                                                                             #
+#                              SITE APPEARANCE                                #
+#                                                                             #
+#                                                                             #
+###############################################################################
+
+#                             ##### https #####
 # Whether external URLs (e.g. used in emails) write emails with "http://" or
 # "https://" prefixes. Set to yes for HTTPS, no for HTTP. Default is no.
 
 https: no
 
+#                      ##### organization_contact #####
+# Change the contact information for the organization in the footer of the
+# website. This information should always remain accurate and correct.
+
+organization_contact:
+  address:
+    street_num: "500"
+    street_name: "East Ave"
+    city: "Rochester"
+    state: "NY"
+    zip: "14607"
+  hours:
+    weekdays: "9am – 5pm"
+    weekends: "closed"
+  phone_num: "(585) 271-4100"
+  email: "racf@racf.org"
+  social_media:
+    facebook: "https://www.facebook.com/GreaterRochesterAfterSchoolAlliance/"
+    twitter: "https://twitter.com/GRASArochester"
+    linkedin: "https://www.linkedin.com/company/rochester-area-community-foundation/"
+  website: "https://www.monroecounty.gov"
+
+#                           ##### site_name #####
+# Creates a resolvable host name used across the website universally. The site
+# name set here reappears multiple times across the project. It is important
+# for this to be an existing DNS record.
+
+site_name: "localhost:8000"

--- a/config.yml.example
+++ b/config.yml.example
@@ -26,6 +26,15 @@ database:
   password: "djangoGrasa2019"
   db: "grasa_event_locator"
 
+#                        ##### mapquest_api_key #####
+# MapQuest Geocoding API key. This must be requested from the MapQuest API.
+# Note there are limitations to what is permitted under the Free Tier. As more
+# search queries are run, be aware of the free limitations of this resource.
+#
+# https://business.mapquest.com/products/geocoding-api/
+
+mapquest_api_key: "nEoQhpyWJ6K3nx0wsur3eVa4oYAfhvhY"
+
 #                          ##### outgoing_smtp #####
 # Edit settings for outgoing SMTP mail server. All emails sent by this web
 # application will be sent through this mail server. For production, this

--- a/grasa_event_locator/templates/createEvent.html
+++ b/grasa_event_locator/templates/createEvent.html
@@ -380,7 +380,7 @@
     //function that geocodes the street address
     function doGeocoding(){
         var streetString = $('#addressInput').val();
-        var api_url = 'http://www.mapquestapi.com/geocoding/v1/address?key=nEoQhpyWJ6K3nx0wsur3eVa4oYAfhvhY&location='+streetString
+        var api_url = 'http://www.mapquestapi.com/geocoding/v1/address?key={{ config.mapquest_api_key }}&location='+streetString
         return fetch(api_url).then((resp) => resp.json()).then(function(data) {
             if(data.info.statuscode === 0){
                  $('#lat').val(data.results[0].locations[0].latLng.lat)

--- a/grasa_event_locator/templates/editEvent.html
+++ b/grasa_event_locator/templates/editEvent.html
@@ -392,7 +392,7 @@
     //function that geocodes the street address
     function doGeocoding(){
         var streetString = $('#addressInput').val();
-        var api_url = 'http://www.mapquestapi.com/geocoding/v1/address?key=nEoQhpyWJ6K3nx0wsur3eVa4oYAfhvhY&location='+streetString
+        var api_url = 'http://www.mapquestapi.com/geocoding/v1/address?key={{ config.mapquest_api_key }}&location='+streetString
         return fetch(api_url).then((resp) => resp.json()).then(function(data) {
             if(data.info.statuscode === 0){
                  $('#lat').val(data.results[0].locations[0].latLng.lat)

--- a/grasa_event_locator/templates/provider.html
+++ b/grasa_event_locator/templates/provider.html
@@ -92,7 +92,7 @@
                                       </div>
                                       <div class="modal-body">
                                         <p>Alternative Contact Information is information for someone else in your organization. This will be used by the administrators in the event that the person who created the account is unreachable, so that the organization will still have access to their events. This information will not be shown with your events.</p>
-                                          <p>More Questions? Please contact us at <a href="mailto:johndoe@email.com">johndoe@email.com</a></p>
+                                          <p>More Questions? Please contact us at <a href="mailto:{{ config.admin_email }}">{{ config.admin_email }}</a>.</p>
                                       </div>
                                       <div class="modal-footer">
                                         <button type="button" class="btn btn-primary" data-dismiss="modal">Ok</button>

--- a/grasa_event_locator/templates/register.html
+++ b/grasa_event_locator/templates/register.html
@@ -107,7 +107,7 @@
                                       </div>
                                       <div class="modal-body">
                                         <p>Alternative Contact Information is information for someone else in your organization. This will be used by the administrators in the event that the person who created the account is unreachable, so that the organization will still have access to their events. This information will not be shown with your events.</p>
-                                          <p>More Questions? Please contact us at <a href="mailto:johndoe@email.com">johndoe@email.com</a></p>
+                                          <p>More Questions? Please contact us at <a href="mailto:{{ config.admin_email }}">{{ config.admin_email }}</a>.</p>
                                       </div>
                                       <div class="modal-footer">
                                         <button type="button" class="btn btn-primary" data-dismiss="modal">Ok</button>

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -474,7 +474,12 @@ def provider(request):
         if request.method == 'POST':
             if request.POST.get('changeemail') and (request.user.username != request.POST['changeemail']):
                 if UserAccount.objects.filter(username=request.POST['changeemail']).exists():
-                    context = {'myEventList': myEventList, 'currentUser': currentUser, 'user_exists' : True}
+                    context = {
+                        'config': settings.CONFIG,
+                        'currentUser': currentUser,
+                        'myEventList': myEventList,
+                        'user_exists': True
+                    }
                     return render(request, 'provider.html', context)
                 else:
                     change_username(request.user.username, request.POST.get('changeemail'), request)
@@ -495,14 +500,23 @@ def provider(request):
                 else:
                     currentUser = userInfo.objects.filter(user=(request.user.userinfo.id - 1))
                     myEventList = Program.objects.filter(user_id=request.user.userinfo.id)
-                    context = {'myEventList': myEventList, 'currentUser': currentUser, 'incorrect_password' : True}
+                    context = {
+                        'config': settings.CONFIG,
+                        'currentUser': currentUser,
+                        'myEventList': myEventList,
+                        'incorrect_password': True,
+                    }
                     return render(request, 'provider.html', context)
             if request.POST.get('delete'):
                 deleteEvent(request, request.POST.get('delete'))
         if request.user.is_authenticated and not request.user.userinfo.isAdmin and not request.user.userinfo.isPending:
                 currentUser = userInfo.objects.filter(user=(request.user.userinfo.id - 1))
                 myEventList = Program.objects.filter(user_id = request.user.userinfo.id)
-                context = {'myEventList' : myEventList, 'currentUser' : currentUser}
+                context = {
+                    'config': settings.CONFIG,
+                    'currentUser': currentUser,
+                    'myEventList': myEventList,
+                }
                 return render(request, 'provider.html', context)
         if request.user.is_authenticated and request.user.userinfo.isAdmin and not request.user.userinfo.isPending:
                 return HttpResponseRedirect(reverse('admin_page'))
@@ -521,7 +535,10 @@ def register(request):
                 #Check for Duplicate Email Entry (Email Already in Database)
                 checkInfo = UserAccount.objects.filter(email=emailAddr)
                 if(checkInfo.count() >= 1):
-                    context = {'emailTaken' : True}
+                    context = {
+                        'config': settings.CONFIG,
+                        'emailTaken': True,
+                    }
                     return render(request, 'register.html', context)
                 else:
                     newUser = UserAccount.objects.create_user(emailAddr, emailAddr, current)
@@ -529,9 +546,15 @@ def register(request):
                     uInfo.save()
                     return redirect('login_page')
         else:
-                context = {'emailTaken' : False}
+                context = {
+                    'config': settings.CONFIG,
+                    'emailTaken': False,
+                }
                 return render(request, 'register.html', context)
-        context = {'emailTaken' : False}
+        context = {
+            'config': settings.CONFIG,
+            'emailTaken': False,
+        }
         return render(request, 'register.html', context)
 
 

--- a/grasa_event_locator/views.py
+++ b/grasa_event_locator/views.py
@@ -191,6 +191,7 @@ def changepw(request):
 
 
 def createevent(request):
+        context = {"config": settings.CONFIG, }
         if request.method == 'POST':
                 g = (str(request.user.userinfo.id))
                 #Only change was to set fees to fees=float(request.POST['fees']) so that the value gets stored in DB as float
@@ -230,8 +231,8 @@ def createevent(request):
                         i = i + 1
                 return HttpResponseRedirect(reverse('provider_page'))
         else:
-                return render(request, 'createEvent.html')
-        return render(request, 'createEvent.html')
+                return render(request, 'createEvent.html', context)
+        return render(request, 'createEvent.html', context)
 
 
 def getEventInfo(eventID):
@@ -287,7 +288,6 @@ def getEventInfo(eventID):
         timing_list_pub = ""
         gender_list_pub = ""
         transportation_list_pub = ""
-        topic_list = event.categories.filter(id__lte=18)
         grades_list = event.categories.filter(id__gte=20)
         grades_list = grades_list.filter(id__lte=24)
         for g in grades_list:
@@ -315,7 +315,16 @@ def getEventInfo(eventID):
         if transportation_list.count() == 0:
                 transportation_list_pub = "Not Provided"
 
-        context = {'event' : event, 'topic_list' : topic_list, 'grades_list_pub' : grades_list_pub, 'timing_list_pub' : timing_list_pub, 'gender_list_pub' : gender_list_pub, 'transportation_list_pub' : transportation_list_pub, 'fees' : "{:0.2f}".format(event.fees)}
+        context = {
+            'config': settings.CONFIG,
+            'event': event,
+            'fees': "{:0.2f}".format(event.fees),
+            'gender_list_pub': gender_list_pub,
+            'grades_list_pub': grades_list_pub,
+            'timing_list_pub': timing_list_pub,
+            'topic_list': event.categories.filter(id__lte=18),
+            'transportation_list_pub': transportation_list_pub,
+        }
 
         tempAddress = context['event'].address.split('+')
         address = []


### PR DESCRIPTION
This PR focuses on our config file and making sure it is used more widely in our application. It also includes some readability improvements. See the commit breakdown below.

Closes #222.

---

883b4fc1b773fcddba2d116fe569143dda7acbe9 — :sparkles: **Use admin contact email in Alt. Contact modal (closes #222)**

This commit closes #222.

This makes some changes to the back-end code to make sure that the
config file is passed into the context of the rendering engine. The
front-end now has the Expressions in place to parse the admin email
where it should be in the Alternative Contact "more info" modal.

Thanks @ldidonato for catching this.

---

8c1c86e3e5d87b5299d4bfe14bf11c2b215535e0 — :heart: **Give organizing love to our config file**

This commit reorganizes and sorts our config file into logically-grouped
sections sorted in alphabetical order.

---

fb5fe6674f3544eb7c44d95b87737a3d8f52b429 — :key: config: Move MapQuest API key to config (closes #222)

This commit moves the hard-coded MapQuest API key out of the template
files and into a config file variable, controlled by an admin.

Closes #222.