### PR TITLE
Got generic formatting to work

### DIFF
--- a/grasa_event_locator/static/css/custom.css
+++ b/grasa_event_locator/static/css/custom.css
@@ -7,6 +7,13 @@ html {
 body{
     margin-bottom: 60px;
 }
+
+pre {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";
+  word-break: break-word!important;
+  overflow-wrap: break-word!important;
+}
+
 .twentyblock{
     height: 20px;
 }

--- a/grasa_event_locator/templates/event.html
+++ b/grasa_event_locator/templates/event.html
@@ -10,7 +10,7 @@
                 <span class="badge badge-info card-title">{{ f }}</span>
             {% endfor %}
             </div>
-            <p class="text-break">{{ event.content }}</p>
+            <p class="text-break"><pre>{{ event.content }}</pre></p>
 
             <h4>Location:</h4>
             <p>


### PR DESCRIPTION
Got generic formatting (new lines, tabs, extra spaces, whatever the shift enter soft newline is, etc.) to work and display properly on event page.