### PR TITLE
Misc. documentation polish on older pages

### DIFF
--- a/docs/about/features.md
+++ b/docs/about/features.md
@@ -1,20 +1,17 @@
-Features
-========
+Features and Systems
+====================
 
-This page references our application features based off system requirements.
-All application features are identified by the following:
+This page explains features across all three systems of the Event Locator:
 
-```
-* **Status**:
-    * Confirmed: Successfully tested items
-    * Unconfirmed: Items not yet successfully tested
-    * Skipped: "Old hat" items
-* **Technology decision**
-* **Summary of approach**
-* **Completion criteria**
-```
+1. Base System
+2. Event Curation System
+3. Search System
 
-Features are organized below by user groups.
+Features are grouped together by which one of the three user groups they impact:
+
+* Families
+* Program Providers
+* GRASA and Monroe County Staff
 
 
 ## Families
@@ -32,7 +29,7 @@ Features are organized below by user groups.
 ### Apply filters to better discover events that interest a user.
 
 * **Status**: Implemented
-* **Technology decision**: [Haystack](https://haystacksearch.org/), [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/), [Jinja](https://palletsprojects.com/p/jinja/), YAML config files
+* **Technology decision**: [Haystack](https://haystacksearch.org/), [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/), [Jinja](https://palletsprojects.com/p/jinja/)
 * **Relevant domain(s)**: Database
 * **Summary of approach**: Create Haystack search filters that mirror metadata we save in our database.
 * **Completion criteria**:
@@ -50,7 +47,7 @@ Features are organized below by user groups.
     * Any user can share a direct link to event page details with another user.
 
 
-## Program providers
+## Program Providers
 
 ### Add new events with specific metadata into system for approval by administrators.
 
@@ -62,13 +59,16 @@ Features are organized below by user groups.
     * Provider is able to log into application.
     * Provider submits new event for review with required details:
         * Title
+        * Description
         * Website
         * Address
         * Suggested age groups
+        * Activity type
+        * Etc.
 
 ### Update information for existing events in system for approval by administrators.
 
-* **Status**: In progress
+* **Status**: Implemented
 * **Technology decision**: [User authentication modules](https://docs.djangoproject.com/en/2.2/topics/auth/) provided in Django, [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/) for basic user input
 * **Relevant domain(s)**: Full stack
 * **Summary of approach**: Allow an authenticated user to edit Forms for events they themselves have created.
@@ -78,7 +78,7 @@ Features are organized below by user groups.
     * Event re-enters review queue for admin users.
 
 
-## GRASA and Monroe County staff
+## GRASA and Monroe County Staff
 
 ### Review and approve submitted events.
 

--- a/docs/dev/setup-dev-environment.md
+++ b/docs/dev/setup-dev-environment.md
@@ -62,11 +62,4 @@ Visit [localhost:8000](http://localhost:8000/) to view the site running locally.
 
 ## Troubleshooting
 
-### Q: On Fedora, `pipenv install` fails with an error: `OSError: mysql_config not found`
 
-Install the `mariadb-connector-c-devel` package.
-It includes the `mysql_config`/`mariadb_config` binary needed to install the `mysqlclient` library.
-
-```sh
-sudo dnf install -y mariadb-connector-c-devel
-```

--- a/docs/dev/troubleshooting.md
+++ b/docs/dev/troubleshooting.md
@@ -9,18 +9,37 @@ Troubleshooting
 This page is a collection of miscellaneous tips, tricks, and other tidbits of info to make it easier to do troubleshooting on the application.
 
 
-## Database change issues
+## Q: On Fedora, Pipenv fails with MySQL config error
 
-Occasionally, you'll get an error that comes from the database changing (field not found, category matching query does not exist).
-You may be able to check for this by going to GitHub Desktop and seeing if `models.py` was changed in the recent commits.
+On Fedora, `pipenv install` may fail with the following error:
 
-The first thing to try is click the _Wipe Events and Recreate Categories_ button in the header.
-See if this helps.
-If not, then in a Terminal window, run `python3 manage.py makemigrations`, and `python3 manage.py migrate`.
+```python
+OSError: mysql_config not found
+```
+
+Install the `mariadb-connector-c-devel` package.
+It includes the `mysql_config`/`mariadb_config` binary needed to install the `mysqlclient` library.
+
+On Fedora:
+
+```sh
+sudo dnf install -y mariadb-connector-c-devel
+```
+
+
+## Database changes during development
+
+Occasionally, you get an error from the database changing (field not found, category matching query does not exist).
+You can check this by checking if `models.py` was changed recently.
+
+Open a shell to the Django container by [exec'ing into the app container](/dev/exec-container).
+Run the following commands:
+
+```sh
+python manage.py makemigrations
+python manage.py migrate
+```
+
 Try the task again.
-
-If that doesn't work, go into the mySQL container, drop the database, create it again.
-Then in the django container, go to the migrations folder with `cd`, and delete all files/folders using `rm` and `rm -r` except for `__init.py__`.
-Run `python3 manage.py makemigrations` and `python3 manage.py migrate`, which should work.
-Go to the website, click the _Create Administrator_ header button and _Wipe Events and Recreate Categories_.
-This gives you a fresh start.
+If it works, make sure the generated database migration script is committed to the git repository along with your other changes.
+If it does not work, try [refreshing your development environment](/dev/start-fresh).


### PR DESCRIPTION
This PR includes some commits to clean up older pages in our documentation. See commit breakdown for an easier time reviewing this PR:

---

269e5fb9003ebcced4c9dbec7174f721ceeed0c7 — :memo: **docs: Refactor "Features" page to "Features and Systems"**

Part of #123, even though it's documentation.

This commit is a final refactor of our Features page. I updated statuses
on all requirements, reworded the page introduction text at the top, and
removed technology decisions that were outdated to our final
implementation. This document is accurate to-date and I do not
anticipate needing to change it again before hand-off.

---

24437812b54cb86902426d3cc417f6343e1ccc67 — :memo: **docs: Merge Troubleshooting section into one page**

Part of #123.

This commit removes the troubleshooting section from the development
environment page and moves it to the troubleshooting page, which makes
more sense. (No duplicating ourselves pls :smile: )

I also refactored the database changes section and shortened it by
linking out to more relevant docs where possible, to explain more
difficult concepts.